### PR TITLE
docs: fixes

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -8,3 +8,7 @@ insert_final_newline = true
 charset = utf-8
 indent_style = tab
 trim_trailing_whitespace = true
+
+# Do not trim trailing whitespace in markdown files as it can be used for line breaks
+[*.md]
+trim_trailing_whitespace = false

--- a/.vscode/extensions.json
+++ b/.vscode/extensions.json
@@ -1,6 +1,9 @@
 {
 	"recommendations": [
-		"swellaby.rust-pack",
-		"dustypomerleau.rust-syntax"
+		"rust-lang.rust-analyzer",
+		"fill-labs.dependi",
+		"tamasfe.even-better-toml",
+		"dustypomerleau.rust-syntax",
+		"editorconfig.editorconfig"
 	]
 }

--- a/crates/batching/README.md
+++ b/crates/batching/README.md
@@ -17,7 +17,7 @@ Often when we are building applications we need to load multiple items from a da
 
 Because we are buffering requests for a short period of time we do see higher latencies when there are not many requests. This is because the overhead from just processing the requests is lower then the time we spend buffering.
 
-However, this is often negated when we have a large number of requests as we see on average lower latencies due to more efficient use of resources. Latency is also more consistent as we are doing fewer requests to the external resource. 
+However, this is often negated when we have a large number of requests as we see on average lower latencies due to more efficient use of resources. Latency is also more consistent as we are doing fewer requests to the external resource.
 
 ## Usage
 

--- a/crates/ffmpeg/README.md
+++ b/crates/ffmpeg/README.md
@@ -19,7 +19,7 @@ TODO(troy): Add documenation about how this crate is different from other ffmpeg
 
 ## Status
 
-This crate is currently under development and is not yet stable, unit tests are not yet fully implemented.
+This crate is currently under development and is not yet stable.
 
 Unit tests are not yet fully implemented. Use at your own risk.
 

--- a/crates/http/README.md
+++ b/crates/http/README.md
@@ -7,7 +7,7 @@
 
 ---
 
-A http server with support for http/1, http/2, http/3 & webtransport. 
+A http server with support for http/1, http/2, http/3 & webtransport.
 
 ## Why do we need this?
 
@@ -15,7 +15,7 @@ TODO(troy): Add more details about why we need this.
 
 ## Status
 
-This crate is currently under development and is not yet stable, unit tests are not yet fully implemented.
+This crate is currently under development and is not yet stable.
 
 Unit tests are not yet fully implemented. Use at your own risk.
 

--- a/crates/metrics/README.md
+++ b/crates/metrics/README.md
@@ -11,7 +11,7 @@ A wrapper around opentelemetry to provide a more ergonomic interface for creatin
 
 ## Status
 
-This crate is currently under development and is not yet stable, unit tests are not yet fully implemented.
+This crate is currently under development and is not yet stable.
 
 Unit tests are not yet fully implemented. Use at your own risk.
 

--- a/crates/postcompile/README.md
+++ b/crates/postcompile/README.md
@@ -56,7 +56,7 @@ In the examples above I showcase how to use this crate with the `insta` crate fo
 
 ## Status
 
-This crate is currently under development and is not yet stable, unit tests are not yet fully implemented.
+This crate is currently under development and is not yet stable.
 
 Unit tests are not yet fully implemented. Use at your own risk.
 

--- a/crates/pprof/README.md
+++ b/crates/pprof/README.md
@@ -11,7 +11,7 @@ A crate designed to provide a more ergonomic interface to the pprof crate.
 
 ## Status
 
-This crate is currently under development and is not yet stable, unit tests are not yet fully implemented.
+This crate is currently under development and is not yet stable.
 
 Unit tests are not yet fully implemented. Use at your own risk.
 

--- a/crates/settings/README.md
+++ b/crates/settings/README.md
@@ -15,7 +15,7 @@ TODO(troy): Add more details about why we need this.
 
 ## Status
 
-This crate is currently under development and is not yet stable, unit tests are not yet fully implemented.
+This crate is currently under development and is not yet stable.
 
 Unit tests are not yet fully implemented. Use at your own risk.
 

--- a/crates/signal/README.md
+++ b/crates/signal/README.md
@@ -7,15 +7,16 @@
 
 ---
 
-A crate designed to provide a more user friendly interface to tokio::signal.
+A crate designed to provide a more user friendly interface to `tokio::signal`.
 
 ## Why do we need this?
 
-The tokio::signal provides a way for us to wait for a signal to be received in a non-blocking way, this crate extends that with a more helpful interface allowing the ability to listen to multiple signals concurrently.
+The `tokio::signal` module provides a way for us to wait for a signal to be received in a non-blocking way.
+This crate extends that with a more helpful interface allowing the ability to listen to multiple signals concurrently.
 
 ## Status
 
-This crate is currently under development and is not yet stable, unit tests are not yet fully implemented.
+This crate is currently under development and is not yet stable.
 
 Unit tests are not yet fully implemented. Use at your own risk.
 


### PR DESCRIPTION
- Fixes some copy paste mistakes in the readmes
- Removes a deprecated vscode plugin recommendation
- Adds other useful vscode plugin recommendations
- Fixes editorconfig for markdown files