### PR TITLE
add orphaned diff finder

### DIFF
--- a/.github/workflows/orphaned.yaml
+++ b/.github/workflows/orphaned.yaml
@@ -1,0 +1,68 @@
+name: "PR Orphaned Diff Finder"
+
+on:
+  pull_request:
+    types: [opened, synchronize, reopened]
+
+jobs:
+  orphaned-diff:
+    runs-on: ubuntu-latest
+
+    permissions:
+      pull-requests: write
+
+    steps:
+      - name: Checkout the PR
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+
+      - name: Generate Final PR Diff
+        id: final_diff
+        run: |
+          git diff ${{ github.event.pull_request.base.sha }} ${{ github.event.pull_request.head.sha }} > final_diff.patch
+          echo "Final diff generated."
+
+      - name: Identify Orphaned Changes
+        id: orphaned_changes
+        run: |
+            echo "## Orphaned Changes" > orphaned_changes.md
+
+            # Fetch the base and head refs
+            git fetch origin ${{ github.event.pull_request.base.ref }}:${{ github.event.pull_request.base.ref }}
+            git fetch origin ${{ github.event.pull_request.head.ref }}:${{ github.event.pull_request.head.ref }}
+
+            git diff ${{ github.event.pull_request.base.sha }} ${{ github.event.pull_request.head.sha }} > final_diff.patch
+            echo "## Orphaned Changes" > orphaned_changes.md
+
+            commits=$(git log ${{ github.event.pull_request.base.sha }}..${{ github.event.pull_request.head.sha }} --pretty=format:"%H" --reverse)
+
+            any_orphaned=false
+
+            for commit in $commits; do
+                echo "Checking commit $commit..."
+                git diff ${commit}^ $commit > commit_diff.patch || true
+
+                # Compare commit diff with final diff
+                ORPHANED=$(diff --unchanged-line-format='' --old-line-format='%L' --new-line-format='' commit_diff.patch final_diff.patch || true)
+
+                if [[ ! -z "$ORPHANED" ]]; then
+                    echo "### Commit $commit" >> orphaned_changes.md
+                    echo '```diff' >> orphaned_changes.md
+                    echo "$ORPHANED" >> orphaned_changes.md
+                    echo '```' >> orphaned_changes.md
+                    echo "" >> orphaned_changes.md
+                    any_orphaned=true
+                fi
+            done
+
+            if [[ "$any_orphaned" = false ]]; then
+                echo "No orphaned changes found."
+                echo "No orphaned changes found." > orphaned_changes.md
+            fi
+
+      - name: Comment on PR with Orphaned Changes
+        uses: marocchino/sticky-pull-request-comment@v2
+        with:
+          header: orphaned-diff
+          path: orphaned_changes.md


### PR DESCRIPTION
Adds a github action that finds differences in PRs that are not in the final PR diff.

For example if 

`Commit A` [**`adds random.bin`**](#)
`Commit B` [**`removes random.bin`**](#)
`Commit C` [**`changes x.py`**](#)

The final PR diff will only show the changes for `x.py` and the `random.bin` addition and removal will not be shown. This action finds and reports those and other line diffs so that we can understand if something has been secretly inserted into git history.