### PR TITLE
fixes doc testing in CI

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -124,7 +124,9 @@ jobs:
       # Note; we don't run the powerset here because it's very slow on CI
       # Perhaps we should consider it at some point.
       - name: Run tests
-        run: cargo +nightly llvm-cov nextest --no-fail-fast --all-features --lcov --output-path ./lcov.info --profile ci
+        run: |
+          cargo +nightly llvm-cov nextest --no-fail-fast --all-features --lcov --output-path ./lcov.info --profile ci
+          cargo +nightly llvm-cov test --all-features --doc --no-report
 
       - name: Codecov Override
         if: ${{ startsWith(github.ref, 'refs/heads/automation/brawl/try/') }}

--- a/Justfile
+++ b/Justfile
@@ -19,8 +19,8 @@ test *args:
     export RUSTUP_TOOLCHAIN=nightly
 
     INSTA_FORCE_PASS=1 cargo llvm-cov clean --workspace
-    INSTA_FORCE_PASS=1 cargo llvm-cov nextest --branch --include-build-script --no-report {{args}}
-    cargo test --doc {{args}}
+    INSTA_FORCE_PASS=1 cargo llvm-cov nextest --include-build-script --no-report {{args}}
+    cargo llvm-cov test --doc --no-report {{args}}
 
     # Do not generate the coverage report on CI
     cargo insta review


### PR DESCRIPTION
Fix a cache issue with doc tests and enable them with ci.

We remove branch coverage here, unfortunately branch coverage is a bit broken. We will have to remove it anyways because it does not work with diesel. Noted by https://github.com/llvm/llvm-project/issues/119558, disabling it now is fine. I hope we can enable it later at somepoint to get back the branch coverage.
