### PR TITLE
add future-ext

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -389,6 +389,7 @@ dependencies = [
  "byteorder",
  "bytes",
  "futures",
+ "scuffle-future-ext",
  "scuffle-workspace-hack",
  "tokio",
  "tokio-stream",
@@ -2308,6 +2309,7 @@ dependencies = [
  "num-derive",
  "num-traits",
  "rand",
+ "scuffle-future-ext",
  "scuffle-workspace-hack",
  "serde_json",
  "sha2",
@@ -2593,6 +2595,14 @@ dependencies = [
 ]
 
 [[package]]
+name = "scuffle-future-ext"
+version = "0.1.0"
+dependencies = [
+ "scuffle-workspace-hack",
+ "tokio",
+]
+
+[[package]]
 name = "scuffle-h3-webtransport"
 version = "0.0.2"
 dependencies = [
@@ -2628,6 +2638,7 @@ dependencies = [
  "rustls",
  "rustls-pemfile",
  "scuffle-context",
+ "scuffle-future-ext",
  "scuffle-h3-webtransport",
  "scuffle-workspace-hack",
  "smallvec",
@@ -2746,6 +2757,7 @@ dependencies = [
  "libc",
  "scuffle-bootstrap",
  "scuffle-context",
+ "scuffle-future-ext",
  "scuffle-workspace-hack",
  "tokio",
 ]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -34,6 +34,7 @@ members = [
     "crates/rtmp",
     "crates/transmuxer",
     "dev-tools/xtask",
+    "crates/future-ext",
 ]
 
 resolver = "2"

--- a/crates/bytesio/Cargo.toml
+++ b/crates/bytesio/Cargo.toml
@@ -20,3 +20,4 @@ scuffle-workspace-hack.workspace = true
 
 [dev-dependencies]
 tokio = { version = "1.36", features = ["full"] }
+scuffle-future-ext = { path = "../future-ext" }

--- a/crates/bytesio/src/tests/errors.rs
+++ b/crates/bytesio/src/tests/errors.rs
@@ -1,10 +1,13 @@
+use scuffle_future_ext::FutureExt;
+
 use crate::bytesio_errors::BytesIOError;
 
 #[tokio::test]
 async fn test_timeout_error_display() {
-    let err = tokio::time::timeout(std::time::Duration::from_millis(100), async {
+    let err = async {
         tokio::time::sleep(std::time::Duration::from_millis(200)).await;
-    })
+    }
+    .with_timeout(std::time::Duration::from_millis(100))
     .await
     .unwrap_err();
     let bytes_io_error = BytesIOError::from(err);

--- a/crates/future-ext/Cargo.toml
+++ b/crates/future-ext/Cargo.toml
@@ -1,0 +1,9 @@
+[package]
+name = "scuffle-future-ext"
+version = "0.1.0"
+edition = "2021"
+license = "MIT OR Apache-2.0"
+
+[dependencies]
+tokio = { version = "1", features = ["time"] }
+scuffle-workspace-hack.workspace = true

--- a/crates/future-ext/src/lib.rs
+++ b/crates/future-ext/src/lib.rs
@@ -1,0 +1,34 @@
+/// The [`FutureExt`] trait is a trait that provides a more ergonomic way to
+/// extend futures with additional functionality. Similar to the [`IteratorExt`]
+/// trait, but for futures.
+pub trait FutureExt {
+    /// Attach a timeout to the future.
+    ///
+    /// This is a convenience method that wraps the [`tokio::time::timeout`]
+    /// function. The future will automatically cancel after the timeout has
+    /// elapsed. This is equivalent to calling
+    /// `with_timeout_at(tokio::time::Instant::now() + duration)`.
+    fn with_timeout(self, duration: tokio::time::Duration) -> tokio::time::Timeout<Self>
+    where
+        Self: Sized;
+
+    /// Attach a timeout to the future.
+    ///
+    /// This is a convenience method that wraps the [`tokio::time::timeout_at`]
+    /// function. The future will automatically cancel after the timeout has
+    /// elapsed. Unlike the `with_timeout` method, this method allows you to
+    /// specify a deadline instead of a duration.
+    fn with_timeout_at(self, deadline: tokio::time::Instant) -> tokio::time::Timeout<Self>
+    where
+        Self: Sized;
+}
+
+impl<F: std::future::Future> FutureExt for F {
+    fn with_timeout(self, duration: tokio::time::Duration) -> tokio::time::Timeout<Self> {
+        tokio::time::timeout(duration, self)
+    }
+
+    fn with_timeout_at(self, deadline: tokio::time::Instant) -> tokio::time::Timeout<Self> {
+        tokio::time::timeout_at(deadline, self)
+    }
+}

--- a/crates/http/Cargo.toml
+++ b/crates/http/Cargo.toml
@@ -25,7 +25,7 @@ itoa = { version = "1" }
 smallvec = { version = "1" }
 spin = { version = "0.9" }
 async-trait = { version = "0.1" }
-
+scuffle-future-ext = { path = "../future-ext" }
 # For extra services features
 tower-service = { version = "0.3", optional = true }
 axum-core = { version = "0.4", optional = true }

--- a/crates/http/src/backend/quic/quinn/serve.rs
+++ b/crates/http/src/backend/quic/quinn/serve.rs
@@ -4,6 +4,7 @@ use bytes::Bytes;
 use h3::server::RequestStream;
 use http::Response;
 use scuffle_context::ContextFutExt;
+use scuffle_future_ext::FutureExt;
 #[cfg(feature = "http3-webtransport")]
 use scuffle_h3_webtransport::server::WebTransportUpgradePending;
 
@@ -122,7 +123,7 @@ async fn serve_handle_inner(
     .with_context(&ctx);
 
     let Some(connection) = if let Some(timeout) = config.handshake_timeout {
-        tokio::time::timeout(timeout, conn).await.with_config(ErrorConfig {
+        conn.with_timeout(timeout).await.with_config(ErrorConfig {
             context: "quinn handshake",
             scope: ErrorScope::Connection,
             severity: ErrorSeverity::Debug,
@@ -147,7 +148,7 @@ async fn serve_handle_inner(
             .with_context(&ctx);
 
         if let Some(timeout) = config.handshake_timeout {
-            tokio::time::timeout(timeout, fut).await.with_config(ErrorConfig {
+            fut.with_timeout(timeout).await.with_config(ErrorConfig {
                 context: "quinn handshake",
                 scope: ErrorScope::Connection,
                 severity: ErrorSeverity::Debug,

--- a/crates/rtmp/Cargo.toml
+++ b/crates/rtmp/Cargo.toml
@@ -22,6 +22,7 @@ tracing = "0.1"
 bytesio = { path = "../bytesio", features = ["default"] }
 amf0 = { path = "../amf0" }
 scuffle-workspace-hack.workspace = true
+scuffle-future-ext = { path = "../future-ext" }
 
 [dev-dependencies]
 tokio = { version = "1.36", features = ["full"] }

--- a/crates/rtmp/src/tests/rtmp.rs
+++ b/crates/rtmp/src/tests/rtmp.rs
@@ -1,6 +1,7 @@
 use std::path::PathBuf;
 use std::time::Duration;
 
+use scuffle_future_ext::FutureExt;
 use tokio::process::Command;
 use tokio::sync::mpsc;
 
@@ -34,7 +35,9 @@ async fn test_basic_rtmp_clean() {
         .spawn()
         .expect("failed to execute ffmpeg");
 
-    let (ffmpeg_stream, _) = tokio::time::timeout(Duration::from_millis(1000), listener.accept())
+    let (ffmpeg_stream, _) = listener
+        .accept()
+        .with_timeout(Duration::from_millis(1000))
         .await
         .expect("timedout")
         .expect("failed to accept");
@@ -55,7 +58,9 @@ async fn test_basic_rtmp_clean() {
         )
     };
 
-    let event = tokio::time::timeout(Duration::from_millis(1000), ffmpeg_event_reciever.recv())
+    let event = ffmpeg_event_reciever
+        .recv()
+        .with_timeout(Duration::from_millis(1000))
         .await
         .expect("timedout")
         .expect("failed to recv event");
@@ -70,7 +75,9 @@ async fn test_basic_rtmp_clean() {
     let mut got_audio = false;
     let mut got_metadata = false;
 
-    while let Some(data) = tokio::time::timeout(Duration::from_millis(1000), ffmpeg_data_reciever.recv())
+    while let Some(data) = ffmpeg_data_reciever
+        .recv()
+        .with_timeout(Duration::from_millis(1000))
         .await
         .expect("timedout")
     {
@@ -119,7 +126,9 @@ async fn test_basic_rtmp_unclean() {
         .spawn()
         .expect("failed to execute ffmpeg");
 
-    let (ffmpeg_stream, _) = tokio::time::timeout(Duration::from_millis(1000), listener.accept())
+    let (ffmpeg_stream, _) = listener
+        .accept()
+        .with_timeout(Duration::from_millis(1000))
         .await
         .expect("timedout")
         .expect("failed to accept");
@@ -140,7 +149,9 @@ async fn test_basic_rtmp_unclean() {
         )
     };
 
-    let event = tokio::time::timeout(Duration::from_millis(1000), ffmpeg_event_reciever.recv())
+    let event = ffmpeg_event_reciever
+        .recv()
+        .with_timeout(Duration::from_millis(1000))
         .await
         .expect("timedout")
         .expect("failed to recv event");
@@ -155,7 +166,9 @@ async fn test_basic_rtmp_unclean() {
     let mut got_audio = false;
     let mut got_metadata = false;
 
-    while let Some(data) = tokio::time::timeout(Duration::from_millis(1000), ffmpeg_data_reciever.recv())
+    while let Some(data) = ffmpeg_data_reciever
+        .recv()
+        .with_timeout(Duration::from_millis(1000))
         .await
         .expect("timedout")
     {

--- a/crates/signal/Cargo.toml
+++ b/crates/signal/Cargo.toml
@@ -21,6 +21,7 @@ scuffle-workspace-hack.workspace = true
 tokio = { version = "1.41.1", features = ["macros", "rt", "time"] }
 libc = "0.2"
 futures = "0.3"
+scuffle-future-ext = { path = "../future-ext" }
 
 [features]
 bootstrap = ["scuffle-bootstrap", "scuffle-context", "anyhow", "tokio/macros"]


### PR DESCRIPTION
I find the syntax for `tokio::time::timeout` to be quite ugly, since it breaks the typical chained method calls. With the FutureExt trait we can just call `.with_timeout(..)` instead which seems to be a cleaner way to do it.