### PR TITLE
fix doc coverage bug

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -125,8 +125,9 @@ jobs:
       # Perhaps we should consider it at some point.
       - name: Run tests
         run: |
-          cargo +nightly llvm-cov nextest --no-fail-fast --all-features --lcov --output-path ./lcov.info --profile ci
-          cargo +nightly llvm-cov test --all-features --doc --no-report
+          cargo +nightly llvm-cov nextest --no-fail-fast --all-features --profile ci --no-report
+          cargo +nightly llvm-cov test --all-features --doc --doctests --no-report
+          cargo +nightly llvm-cov report --doctests --lcov --output-path ./lcov.info
 
       - name: Codecov Override
         if: ${{ startsWith(github.ref, 'refs/heads/automation/brawl/try/') }}

--- a/Justfile
+++ b/Justfile
@@ -19,13 +19,13 @@ test *args:
     export RUSTUP_TOOLCHAIN=nightly
 
     INSTA_FORCE_PASS=1 cargo llvm-cov clean --workspace
-    INSTA_FORCE_PASS=1 cargo llvm-cov nextest --include-build-script --no-report {{args}}
-    cargo llvm-cov test --doc --no-report {{args}}
+    INSTA_FORCE_PASS=1 cargo llvm-cov nextest --include-build-script --no-report -- {{args}}
+    cargo llvm-cov test --doc --doctests --no-report -- {{args}}
 
     # Do not generate the coverage report on CI
     cargo insta review
-    cargo llvm-cov report --html
-    cargo llvm-cov report --lcov --output-path ./lcov.info
+    cargo llvm-cov report --lcov --doctests --output-path ./lcov.info
+    cargo llvm-cov report --html --doctests
 
 deny *args:
     cargo deny {{args}} --all-features check


### PR DESCRIPTION
For some reason cargo llvm-cov report does not include doc coverage even if the doc coverage profraw files are there. It seems you also need to
 add the flag `--doctests` to the report command.

I opened an upstream issue to see if this is the desired behaviour or not. It seems a bit unintuitive.

https://github.com/taiki-e/cargo-llvm-cov/issues/412
