### PR TITLE
Fix h264 num_units_in_tick divide by zero

### DIFF
--- a/crates/h264/src/sps.rs
+++ b/crates/h264/src/sps.rs
@@ -183,6 +183,11 @@ impl Sps {
             if bit_reader.read_bit()? {
                 let num_units_in_tick = bit_reader.read_u32::<BigEndian>()?;
                 let time_scale = bit_reader.read_u32::<BigEndian>()?;
+
+                if num_units_in_tick == 0 {
+                    return Err(io::Error::new(io::ErrorKind::InvalidData, "num_units_in_tick cannot be zero"));
+                }
+
                 frame_rate = time_scale as f64 / (2.0 * num_units_in_tick as f64);
             }
         }

--- a/crates/h264/src/tests.rs
+++ b/crates/h264/src/tests.rs
@@ -146,7 +146,7 @@ fn test_config_mux() {
 
 #[test]
 fn test_parse_sps_with_zero_num_units_in_tick() {
-    let sps: Bytes = Bytes::from(b"gd\0\x1f\xac\xd9A\xe0m\xf9\xe6\xa0  (\0\0\x03\0\0\0\0\x03\x01\xe0x\xc1\x8c\xb0 ".to_vec());
+    let sps = Bytes::from(b"gd\0\x1f\xac\xd9A\xe0m\xf9\xe6\xa0  (\0\0\x03\0\0\0\0\x03\x01\xe0x\xc1\x8c\xb0 ".to_vec());
     let sps = Sps::parse(sps);
 
     match sps {

--- a/crates/h264/src/tests.rs
+++ b/crates/h264/src/tests.rs
@@ -143,3 +143,19 @@ fn test_config_mux() {
 
     assert_eq!(buf, data.to_vec());
 }
+
+#[test]
+fn test_parse_sps_with_zero_num_units_in_tick() {
+    let sps: Bytes = Bytes::from(b"gd\0\x1f\xac\xd9A\xe0m\xf9\xe6\xa0  (\0\0\x03\0\0\0\0\x03\x01\xe0x\xc1\x8c\xb0 ".to_vec());
+    let sps = Sps::parse(sps);
+
+    match sps {
+        Ok(_) => panic!("Expected error for num_units_in_tick = 0, but got Ok"),
+        Err(e) => assert_eq!(
+            e.kind(),
+            std::io::ErrorKind::InvalidData,
+            "Expected InvalidData error, got {:?}",
+            e
+        ),
+    }
+}


### PR DESCRIPTION
The SPS parser panics when num_units_in_tick is 0. Included a test to ensure it doesn't happen again :)