### PR TITLE
revert nightly to older build

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -39,7 +39,7 @@ jobs:
           shared-key: clippy
 
       - name: Make sure code is linted
-        run: cargo clippy
+        run: cargo +${{ env.RUST_TOOLCHAIN }} clippy
 
   fmt:
     name: Fmt
@@ -56,7 +56,7 @@ jobs:
           components: rustfmt
 
       - name: Make sure code is formatted
-        run: cargo fmt --check
+        run: cargo +${{ env.RUST_TOOLCHAIN }} fmt --check
 
   hakari:
     name: Hakari
@@ -77,9 +77,9 @@ jobs:
         run: |
           set -xeo pipefail
 
-          cargo hakari manage-deps --dry-run
-          cargo hakari generate --diff
-          cargo hakari verify
+          cargo +${{ env.RUST_TOOLCHAIN }} hakari manage-deps --dry-run
+          cargo +${{ env.RUST_TOOLCHAIN }} hakari generate --diff
+          cargo +${{ env.RUST_TOOLCHAIN }} hakari verify
 
   test:
     name: Test
@@ -131,9 +131,9 @@ jobs:
       # Once it fully works we can add the `--doctests` flag to the test and report command again.
       - name: Run tests
         run: |
-          cargo llvm-cov nextest --no-fail-fast --all-features --profile ci --no-report
-          cargo llvm-cov test --all-features --doc --no-report
-          cargo llvm-cov report --lcov --output-path ./lcov.info
+          cargo +${{ env.RUST_TOOLCHAIN }} llvm-cov nextest --no-fail-fast --all-features --profile ci --no-report
+          cargo +${{ env.RUST_TOOLCHAIN }} llvm-cov test --all-features --doc --no-report
+          cargo +${{ env.RUST_TOOLCHAIN }} llvm-cov report --lcov --output-path ./lcov.info
 
       - name: Codecov Override
         if: ${{ startsWith(github.ref, 'refs/heads/automation/brawl/try/') }}

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -12,6 +12,9 @@ concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}
   cancel-in-progress: true
 
+env:
+  RUST_TOOLCHAIN: nightly-2025-01-06
+
 jobs:
   clippy:
     name: Clippy
@@ -26,7 +29,7 @@ jobs:
       - uses: dtolnay/rust-toolchain@stable
         id: setup-rust
         with:
-          toolchain: nightly
+          toolchain: ${{ env.RUST_TOOLCHAIN }}
           components: clippy
 
       - uses: Swatinem/rust-cache@v2
@@ -36,7 +39,7 @@ jobs:
           shared-key: clippy
 
       - name: Make sure code is linted
-        run: cargo +nightly clippy
+        run: cargo clippy
 
   fmt:
     name: Fmt
@@ -49,11 +52,11 @@ jobs:
       - uses: dtolnay/rust-toolchain@stable
         id: setup-rust
         with:
-          toolchain: nightly
+          toolchain: ${{ env.RUST_TOOLCHAIN }}
           components: rustfmt
 
       - name: Make sure code is formatted
-        run: cargo +nightly fmt --check
+        run: cargo fmt --check
 
   hakari:
     name: Hakari
@@ -64,7 +67,7 @@ jobs:
       - uses: dtolnay/rust-toolchain@stable
         id: setup-rust
         with:
-          toolchain: nightly
+          toolchain: ${{ env.RUST_TOOLCHAIN }}
 
       - uses: taiki-e/install-action@v2
         with:
@@ -91,7 +94,7 @@ jobs:
       - uses: dtolnay/rust-toolchain@stable
         id: setup-rust
         with:
-          toolchain: nightly
+          toolchain: ${{ env.RUST_TOOLCHAIN }}
           components: llvm-tools-preview
 
       - name: Install ffmpeg
@@ -128,9 +131,9 @@ jobs:
       # Once it fully works we can add the `--doctests` flag to the test and report command again.
       - name: Run tests
         run: |
-          cargo +nightly llvm-cov nextest --no-fail-fast --all-features --profile ci --no-report
-          cargo +nightly llvm-cov test --all-features --doc --no-report
-          cargo +nightly llvm-cov report --lcov --output-path ./lcov.info
+          cargo llvm-cov nextest --no-fail-fast --all-features --profile ci --no-report
+          cargo llvm-cov test --all-features --doc --no-report
+          cargo llvm-cov report --lcov --output-path ./lcov.info
 
       - name: Codecov Override
         if: ${{ startsWith(github.ref, 'refs/heads/automation/brawl/try/') }}

--- a/Justfile
+++ b/Justfile
@@ -16,7 +16,9 @@ test *args:
     set -euo pipefail
 
     # We use the nightly toolchain for coverage since it supports branch & no-coverage flags.
-    export RUSTUP_TOOLCHAIN=nightly
+    if [ -z ${RUST_TOOLCHAIN+x} ]; then
+        export RUSTUP_TOOLCHAIN=nightly
+    fi
 
     INSTA_FORCE_PASS=1 cargo llvm-cov clean --workspace
     INSTA_FORCE_PASS=1 cargo llvm-cov nextest --include-build-script --no-report -- {{args}}


### PR DESCRIPTION
the latest nightly broke on coverage checking so we pin it back to continue working. We will unpin it after nightly has been fixed.
