### PR TITLE
cleanup scuffle-av1 header decoder

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -187,16 +187,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ace50bade8e6234aa140d9a2f552bbee1db4d353f69b8217bc503490fc1a9f26"
 
 [[package]]
-name = "av1"
-version = "0.0.1"
-dependencies = [
- "byteorder",
- "bytes",
- "scuffle-bytes-util",
- "scuffle-workspace-hack",
-]
-
-[[package]]
 name = "aws-lc-rs"
 version = "1.11.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -947,7 +937,6 @@ dependencies = [
 name = "flv"
 version = "0.0.1"
 dependencies = [
- "av1",
  "byteorder",
  "bytes",
  "h264",
@@ -956,6 +945,7 @@ dependencies = [
  "num-traits",
  "scuffle-aac",
  "scuffle-amf0",
+ "scuffle-av1",
  "scuffle-bytes-util",
  "scuffle-workspace-hack",
 ]
@@ -1591,7 +1581,6 @@ dependencies = [
 name = "mp4"
 version = "0.0.1"
 dependencies = [
- "av1",
  "byteorder",
  "bytes",
  "fixed",
@@ -1599,6 +1588,7 @@ dependencies = [
  "h265",
  "paste",
  "scuffle-aac",
+ "scuffle-av1",
  "scuffle-bytes-util",
  "scuffle-workspace-hack",
  "serde",
@@ -2496,6 +2486,17 @@ dependencies = [
 ]
 
 [[package]]
+name = "scuffle-av1"
+version = "0.0.1"
+dependencies = [
+ "byteorder",
+ "bytes",
+ "insta",
+ "scuffle-bytes-util",
+ "scuffle-workspace-hack",
+]
+
+[[package]]
 name = "scuffle-batching"
 version = "0.0.4"
 dependencies = [
@@ -3376,7 +3377,6 @@ dependencies = [
 name = "transmuxer"
 version = "0.0.1"
 dependencies = [
- "av1",
  "byteorder",
  "bytes",
  "flv",
@@ -3385,6 +3385,7 @@ dependencies = [
  "mp4",
  "scuffle-aac",
  "scuffle-amf0",
+ "scuffle-av1",
  "scuffle-bytes-util",
  "scuffle-workspace-hack",
  "serde",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -62,6 +62,7 @@ scuffle-future-ext = { path = "crates/future-ext", version = "0.0.1" }
 scuffle-bytes-util = { path = "crates/bytes-util", version = "0.0.1" }
 scuffle-expgolomb = { path = "crates/expgolomb", version = "0.0.1" }
 scuffle-amf0 = { path = "crates/amf0", version = "0.0.1" }
+scuffle-av1 = { path = "crates/av1", version = "0.0.1" }
 
 [profile.release-debug]
 inherits = "release"

--- a/crates/av1/Cargo.toml
+++ b/crates/av1/Cargo.toml
@@ -1,11 +1,23 @@
 [package]
-name = "av1"
+name = "scuffle-av1"
 version = "0.0.1"
 edition = "2021"
 license = "MIT OR Apache-2.0"
+repository = "https://github.com/scufflecloud/scuffle"
+authors = ["Scuffle <opensource@scuffle.cloud>"]
+readme = "README.md"
+documentation = "https://docs.rs/scuffle-av1"
+description = "AV1 codec header decoding & encoding."
+keywords = ["av1", "header", "decoding", "encoding"]
+
+[lints.rust]
+unexpected_cfgs = { level = "warn", check-cfg = ['cfg(coverage_nightly)'] }
 
 [dependencies]
 bytes = "1.5"
 byteorder = "1.5"
 scuffle-bytes-util.workspace = true
 scuffle-workspace-hack.workspace = true
+
+[dev-dependencies]
+insta = "1.2"

--- a/crates/av1/LICENSE.Apache-2.0
+++ b/crates/av1/LICENSE.Apache-2.0
@@ -1,0 +1,1 @@
+../../LICENSE.Apache-2.0

--- a/crates/av1/LICENSE.MIT
+++ b/crates/av1/LICENSE.MIT
@@ -1,0 +1,1 @@
+../../LICENSE.MIT

--- a/crates/av1/README.md
+++ b/crates/av1/README.md
@@ -1,95 +1,13 @@
-# scuffle-batching
+# scuffle-av1
 
 > [!WARNING]  
 > This crate is under active development and may not be stable.
 
- [![crates.io](https://img.shields.io/crates/v/scuffle-batching.svg)](https://crates.io/crates/scuffle-batching) [![docs.rs](https://img.shields.io/docsrs/scuffle-batching)](https://docs.rs/scuffle-batching)
+ [![crates.io](https://img.shields.io/crates/v/scuffle-av1.svg)](https://crates.io/crates/scuffle-av1) [![docs.rs](https://img.shields.io/docsrs/scuffle-av1)](https://docs.rs/scuffle-av1)
 
 ---
 
-A crate designed to batch multiple requests into a single request.
-
-## Why do we need this?
-
-Often when we are building applications we need to load multiple items from a database or some other external resource. It is often expensive to load each item individually, and this is typically why most drivers have some form of multi-item loading or executing. This crate provides an improved version of this functionality by combining multiple calls from different scopes into a single batched request.
-
-## Tradeoffs
-
-Because we are buffering requests for a short period of time we do see higher latencies when there are not many requests. This is because the overhead from just processing the requests is lower then the time we spend buffering.
-
-However, this is often negated when we have a large number of requests as we see on average lower latencies due to more efficient use of resources. Latency is also more consistent as we are doing fewer requests to the external resource.
-
-## Usage
-
-Here is an example of how to use the `DataLoader` interface to batch multiple reads from a database.
-
-```rust
-struct MyUserLoader(SomeDatabase);
-
-impl DataLoaderFetcher for MyUserLoader {
-    type Key = i64;
-    type Value = User;
-
-    async fn load(&self, keys: HashSet<Self::Key>) -> Option<HashMap<Self::Key, Self::Value>> {
-        let users = self.0.fetch("SELECT * FROM users WHERE id IN ($1)").bind(keys).await.map_err(|e| {
-            eprintln!("Failed to fetch users: {}", e);
-        }).ok()?;
-
-        Some(users.into_iter().map(|user| (user.id, user)).collect())
-    }
-}
-
-let loader = DataLoaderBuilder::new().build(MyUserLoader(database));
-
-// Will only make a single request to the database and load both users
-// You can also use `loader.load_many` if you have more then one item to load.
-let (user1, user2): (Result<_, _>, Result<_, _>) = tokio::join!(loader.load(1), loader.load(2));
-```
-
-Another use case might be to batch multiple writes to a database.
-
-```rust
-struct MyUserUpdater(SomeDatabase);
-
-impl BatchExecutor for MyUserUpdater {
-    type Request = User;
-    type Response = bool;
-
-    async fn execute(&self, requests: Vec<(Self::Request, BatchResponse<Self::Response>)>) {
-        let (users, responses): (Vec<Self::Request>, Vec<BatchResponse<Self::Response>>) = requests.into_iter().unzip();
-
-        // You would need to build the query somehow, this is just an example
-        if let Err(e) = self.0.update("INSERT INTO users (id, name) VALUES ($1, $2), ($3, $4)").bind(users).await {
-            eprintln!("Failed to insert users: {}", e);
-
-            for response in responses {
-                // Reply back saying we failed
-                response.send(false);
-            }
-
-            return;
-        }
-
-        // Reply back to the client that we successfully inserted the users
-        for response in responses {
-            response.send(true);
-        }
-    }
-}
-
-let batcher = BatcherBuilder::new().build(MyUserUpdater(database));
-// Will only make a single request to the database and insert both users
-// You can also use `batcher.execute_many` if you have more then one item to insert.
-let (success1, success2) = tokio::join!(batcher.execute(user1), batcher.execute(user2));
-
-if success1.is_some_and(|s| !s) {
-    eprintln!("Failed to insert user 1");
-}
-
-if success2.is_some_and(|s| !s) {
-    eprintln!("Failed to insert user 2");
-}
-```
+A crate for decoding and encoding AV1 video headers.
 
 ## License
 

--- a/crates/av1/README.md
+++ b/crates/av1/README.md
@@ -3,7 +3,7 @@
 > [!WARNING]  
 > This crate is under active development and may not be stable.
 
- [![crates.io](https://img.shields.io/crates/v/scuffle-av1.svg)](https://crates.io/crates/scuffle-av1) [![docs.rs](https://img.shields.io/docsrs/scuffle-av1)](https://docs.rs/scuffle-av1)
+[![crates.io](https://img.shields.io/crates/v/scuffle-av1.svg)](https://crates.io/crates/scuffle-av1) [![docs.rs](https://img.shields.io/docsrs/scuffle-av1)](https://docs.rs/scuffle-av1)
 
 ---
 

--- a/crates/av1/README.md
+++ b/crates/av1/README.md
@@ -1,0 +1,99 @@
+# scuffle-batching
+
+> [!WARNING]  
+> This crate is under active development and may not be stable.
+
+ [![crates.io](https://img.shields.io/crates/v/scuffle-batching.svg)](https://crates.io/crates/scuffle-batching) [![docs.rs](https://img.shields.io/docsrs/scuffle-batching)](https://docs.rs/scuffle-batching)
+
+---
+
+A crate designed to batch multiple requests into a single request.
+
+## Why do we need this?
+
+Often when we are building applications we need to load multiple items from a database or some other external resource. It is often expensive to load each item individually, and this is typically why most drivers have some form of multi-item loading or executing. This crate provides an improved version of this functionality by combining multiple calls from different scopes into a single batched request.
+
+## Tradeoffs
+
+Because we are buffering requests for a short period of time we do see higher latencies when there are not many requests. This is because the overhead from just processing the requests is lower then the time we spend buffering.
+
+However, this is often negated when we have a large number of requests as we see on average lower latencies due to more efficient use of resources. Latency is also more consistent as we are doing fewer requests to the external resource.
+
+## Usage
+
+Here is an example of how to use the `DataLoader` interface to batch multiple reads from a database.
+
+```rust
+struct MyUserLoader(SomeDatabase);
+
+impl DataLoaderFetcher for MyUserLoader {
+    type Key = i64;
+    type Value = User;
+
+    async fn load(&self, keys: HashSet<Self::Key>) -> Option<HashMap<Self::Key, Self::Value>> {
+        let users = self.0.fetch("SELECT * FROM users WHERE id IN ($1)").bind(keys).await.map_err(|e| {
+            eprintln!("Failed to fetch users: {}", e);
+        }).ok()?;
+
+        Some(users.into_iter().map(|user| (user.id, user)).collect())
+    }
+}
+
+let loader = DataLoaderBuilder::new().build(MyUserLoader(database));
+
+// Will only make a single request to the database and load both users
+// You can also use `loader.load_many` if you have more then one item to load.
+let (user1, user2): (Result<_, _>, Result<_, _>) = tokio::join!(loader.load(1), loader.load(2));
+```
+
+Another use case might be to batch multiple writes to a database.
+
+```rust
+struct MyUserUpdater(SomeDatabase);
+
+impl BatchExecutor for MyUserUpdater {
+    type Request = User;
+    type Response = bool;
+
+    async fn execute(&self, requests: Vec<(Self::Request, BatchResponse<Self::Response>)>) {
+        let (users, responses): (Vec<Self::Request>, Vec<BatchResponse<Self::Response>>) = requests.into_iter().unzip();
+
+        // You would need to build the query somehow, this is just an example
+        if let Err(e) = self.0.update("INSERT INTO users (id, name) VALUES ($1, $2), ($3, $4)").bind(users).await {
+            eprintln!("Failed to insert users: {}", e);
+
+            for response in responses {
+                // Reply back saying we failed
+                response.send(false);
+            }
+
+            return;
+        }
+
+        // Reply back to the client that we successfully inserted the users
+        for response in responses {
+            response.send(true);
+        }
+    }
+}
+
+let batcher = BatcherBuilder::new().build(MyUserUpdater(database));
+// Will only make a single request to the database and insert both users
+// You can also use `batcher.execute_many` if you have more then one item to insert.
+let (success1, success2) = tokio::join!(batcher.execute(user1), batcher.execute(user2));
+
+if success1.is_some_and(|s| !s) {
+    eprintln!("Failed to insert user 1");
+}
+
+if success2.is_some_and(|s| !s) {
+    eprintln!("Failed to insert user 2");
+}
+```
+
+## License
+
+This project is licensed under the [MIT](./LICENSE.MIT) or [Apache-2.0](./LICENSE.Apache-2.0) license.
+You can choose between one of them if you use this work.
+
+`SPDX-License-Identifier: MIT OR Apache-2.0`

--- a/crates/av1/src/config.rs
+++ b/crates/av1/src/config.rs
@@ -145,6 +145,33 @@ mod tests {
     }
 
     #[test]
+    fn test_config_demux_with_initial_presentation_delay() {
+        let data = b"\x81\r\x0c\x3f\n\x0f\0\0\0j\xef\xbf\xe1\xbc\x02\x19\x90\x10\x10\x10@".to_vec();
+
+        let config = AV1CodecConfigurationRecord::demux(&mut io::Cursor::new(data.into())).unwrap();
+
+        insta::assert_debug_snapshot!(config, @r#"
+        AV1CodecConfigurationRecord {
+            marker: true,
+            version: 1,
+            seq_profile: 0,
+            seq_level_idx_0: 13,
+            seq_tier_0: false,
+            high_bitdepth: false,
+            twelve_bit: false,
+            monochrome: false,
+            chroma_subsampling_x: true,
+            chroma_subsampling_y: true,
+            chroma_sample_position: 0,
+            initial_presentation_delay_minus_one: Some(
+                15,
+            ),
+            config_obu: b"\n\x0f\0\0\0j\xef\xbf\xe1\xbc\x02\x19\x90\x10\x10\x10@",
+        }
+        "#);
+    }
+
+    #[test]
     fn test_config_mux() {
         let config = AV1CodecConfigurationRecord {
             marker: true,

--- a/crates/av1/src/lib.rs
+++ b/crates/av1/src/lib.rs
@@ -1,8 +1,7 @@
+#![cfg_attr(all(coverage_nightly, test), feature(coverage_attribute))]
+
 mod config;
 mod obu;
 
 pub use config::AV1CodecConfigurationRecord;
 pub use obu::{seq, ObuHeader, ObuType};
-
-#[cfg(test)]
-mod tests;

--- a/crates/av1/src/lib.rs
+++ b/crates/av1/src/lib.rs
@@ -6,8 +6,9 @@
 //!
 //! ## License
 //!
-//! This project is licensed under the [MIT](./LICENSE.MIT) or [Apache-2.0](./LICENSE.Apache-2.0) license.
-//! You can choose between one of them if you use this work.
+//! This project is licensed under the [MIT](./LICENSE.MIT) or
+//! [Apache-2.0](./LICENSE.Apache-2.0) license. You can choose between one of
+//! them if you use this work.
 //!
 //! `SPDX-License-Identifier: MIT OR Apache-2.0`
 #![cfg_attr(all(coverage_nightly, test), feature(coverage_attribute))]

--- a/crates/av1/src/lib.rs
+++ b/crates/av1/src/lib.rs
@@ -1,3 +1,15 @@
+//! # scuffle-av1
+//!
+//! [![crates.io](https://img.shields.io/crates/v/scuffle-av1.svg)](https://crates.io/crates/scuffle-av1) [![docs.rs](https://img.shields.io/docsrs/scuffle-av1)](https://docs.rs/scuffle-av1)
+//!
+//! A crate for decoding and encoding AV1 video headers.
+//!
+//! ## License
+//!
+//! This project is licensed under the [MIT](./LICENSE.MIT) or [Apache-2.0](./LICENSE.Apache-2.0) license.
+//! You can choose between one of them if you use this work.
+//!
+//! `SPDX-License-Identifier: MIT OR Apache-2.0`
 #![cfg_attr(all(coverage_nightly, test), feature(coverage_attribute))]
 
 mod config;

--- a/crates/av1/src/obu/mod.rs
+++ b/crates/av1/src/obu/mod.rs
@@ -172,7 +172,7 @@ mod tests {
             ),
             size: None,
             extension_header: Some(
-                ObuHeaderExtension {
+                ObuExtensionHeader {
                     temporal_id: 6,
                     spatial_id: 2,
                 },

--- a/crates/av1/src/obu/mod.rs
+++ b/crates/av1/src/obu/mod.rs
@@ -35,10 +35,7 @@ impl ObuHeader {
         let extension_flag = bit_reader.read_bit()?;
         let has_size_field = bit_reader.read_bit()?;
 
-        let reserved_1bit = bit_reader.read_bit()?;
-        if reserved_1bit {
-            return Err(io::Error::new(io::ErrorKind::InvalidData, "obu_reserved_1bit is not 0"));
-        }
+        bit_reader.read_bit()?; // reserved_1bit
 
         let extension_header = if extension_flag {
             let temporal_id = bit_reader.read_bits(3)?;
@@ -197,17 +194,6 @@ mod tests {
         Custom {
             kind: InvalidData,
             error: "obu_forbidden_bit is not 0",
-        }
-        "#);
-    }
-
-    #[test]
-    fn test_obu_header_parse_invalid_obu_type() {
-        let err = ObuHeader::parse(&mut std::io::Cursor::new(b"\x01")).unwrap_err();
-        insta::assert_debug_snapshot!(err, @r#"
-        Custom {
-            kind: InvalidData,
-            error: "obu_reserved_1bit is not 0",
         }
         "#);
     }

--- a/crates/av1/src/obu/mod.rs
+++ b/crates/av1/src/obu/mod.rs
@@ -12,13 +12,13 @@ mod utils;
 pub struct ObuHeader {
     pub obu_type: ObuType,
     pub size: Option<u64>,
-    pub extension_header: Option<ObuHeaderExtension>,
+    pub extension_header: Option<ObuExtensionHeader>,
 }
 
 /// Obu Header Extension
 /// AV1-Spec-2 - 5.3.3
 #[derive(Debug, Clone, PartialEq, Eq, Copy)]
-pub struct ObuHeaderExtension {
+pub struct ObuExtensionHeader {
     pub temporal_id: u8,
     pub spatial_id: u8,
 }
@@ -41,7 +41,7 @@ impl ObuHeader {
             let temporal_id = bit_reader.read_bits(3)?;
             let spatial_id = bit_reader.read_bits(2)?;
             bit_reader.read_bits(3)?; // reserved_3bits
-            Some(ObuHeaderExtension {
+            Some(ObuExtensionHeader {
                 temporal_id: temporal_id as u8,
                 spatial_id: spatial_id as u8,
             })

--- a/crates/av1/src/obu/seq.rs
+++ b/crates/av1/src/obu/seq.rs
@@ -1,15 +1,14 @@
 use std::io;
 
 use byteorder::{BigEndian, ReadBytesExt};
-use bytes::Bytes;
 use scuffle_bytes_util::BitReader;
 
 use super::ObuHeader;
-use crate::obu::read_uvlc;
+use crate::obu::utils::read_uvlc;
 
-#[derive(Debug, Clone, PartialEq)]
 /// Sequence Header OBU
 /// AV1-Spec-2 - 5.5
+#[derive(Debug, Clone, PartialEq, Eq)]
 pub struct SequenceHeaderObu {
     pub header: ObuHeader,
     pub seq_profile: u8,
@@ -41,13 +40,13 @@ pub struct SequenceHeaderObu {
     pub film_grain_params_present: bool,
 }
 
-#[derive(Debug, Clone, PartialEq)]
+#[derive(Debug, Clone, PartialEq, Eq, Copy)]
 pub struct FrameIds {
     pub delta_frame_id_length: u8,
     pub additional_frame_id_length: u8,
 }
 
-#[derive(Debug, Clone, PartialEq)]
+#[derive(Debug, Clone, PartialEq, Eq, Copy)]
 pub struct OperatingPoint {
     pub idc: u16,
     pub seq_level_idx: u8,
@@ -56,14 +55,14 @@ pub struct OperatingPoint {
     pub initial_display_delay: Option<u8>,
 }
 
-#[derive(Debug, Clone, PartialEq)]
+#[derive(Debug, Clone, PartialEq, Eq, Copy)]
 pub struct TimingInfo {
     pub num_units_in_display_tick: u32,
     pub time_scale: u32,
     pub num_ticks_per_picture: Option<u64>,
 }
 
-#[derive(Debug, Clone, PartialEq)]
+#[derive(Debug, Clone, PartialEq, Eq, Copy)]
 pub struct DecoderModelInfo {
     pub buffer_delay_length: u8,
     pub num_units_in_decoding_tick: u32,
@@ -71,14 +70,14 @@ pub struct DecoderModelInfo {
     pub frame_presentation_time_length: u8,
 }
 
-#[derive(Debug, Clone, PartialEq)]
+#[derive(Debug, Clone, PartialEq, Eq, Copy)]
 pub struct OperatingParametersInfo {
     pub decoder_buffer_delay: u64,
     pub encoder_buffer_delay: u64,
     pub low_delay_mode_flag: bool,
 }
 
-#[derive(Debug, Clone, PartialEq)]
+#[derive(Debug, Clone, PartialEq, Eq, Copy)]
 pub struct ColorConfig {
     pub bit_depth: i32,
     pub mono_chrome: bool,
@@ -93,13 +92,148 @@ pub struct ColorConfig {
     pub separate_uv_delta_q: bool,
 }
 
+#[derive(Debug, Clone, PartialEq, Eq, Copy)]
+struct ColorRangeAndSubsampling {
+    color_range: bool,
+    subsampling_x: bool,
+    subsampling_y: bool,
+}
+
+impl ColorConfig {
+    fn parse_color_range_and_subsampling(
+        bit_reader: &mut BitReader<impl io::Read>,
+        seq_profile: u8,
+        color_primaries: u8,
+        transfer_characteristics: u8,
+        matrix_coefficients: u8,
+        bit_depth: i32,
+    ) -> io::Result<ColorRangeAndSubsampling> {
+        let color_range;
+        let subsampling_x;
+        let subsampling_y;
+
+        const CP_BT_709: u8 = 1;
+        const TC_SRGB: u8 = 13;
+        const MC_IDENTITY: u8 = 0;
+
+        if color_primaries == CP_BT_709 && transfer_characteristics == TC_SRGB && matrix_coefficients == MC_IDENTITY {
+            color_range = true;
+            subsampling_x = false;
+            subsampling_y = false;
+        } else {
+            color_range = bit_reader.read_bit()?;
+            if seq_profile == 0 {
+                subsampling_x = true;
+                subsampling_y = true;
+            } else if seq_profile == 1 {
+                subsampling_x = false;
+                subsampling_y = false;
+            } else if bit_depth == 12 {
+                subsampling_x = bit_reader.read_bit()?;
+                if subsampling_x {
+                    subsampling_y = bit_reader.read_bit()?;
+                } else {
+                    subsampling_y = false;
+                }
+            } else {
+                subsampling_x = true;
+                subsampling_y = false;
+            }
+        }
+
+        Ok(ColorRangeAndSubsampling {
+            color_range,
+            subsampling_x,
+            subsampling_y,
+        })
+    }
+
+    pub fn parse(seq_profile: u8, bit_reader: &mut BitReader<impl io::Read>) -> io::Result<Self> {
+        let high_bitdepth = bit_reader.read_bit()?;
+        let bit_depth = match (seq_profile, high_bitdepth) {
+            (2, true) if bit_reader.read_bit()? => 12,
+            (_, true) => 10,
+            (_, false) => 8,
+        };
+
+        let mono_chrome = if seq_profile == 1 { false } else { bit_reader.read_bit()? };
+
+        let color_primaries;
+        let transfer_characteristics;
+        let matrix_coefficients;
+
+        let color_description_present_flag = bit_reader.read_bit()?;
+        if color_description_present_flag {
+            color_primaries = bit_reader.read_bits(8)? as u8;
+            transfer_characteristics = bit_reader.read_bits(8)? as u8;
+            matrix_coefficients = bit_reader.read_bits(8)? as u8;
+        } else {
+            color_primaries = 2; // CP_UNSPECIFIED
+            transfer_characteristics = 2; // TC_UNSPECIFIED
+            matrix_coefficients = 2; // MC_UNSPECIFIED
+        }
+
+        let num_planes = if mono_chrome { 1 } else { 3 };
+
+        if mono_chrome {
+            Ok(ColorConfig {
+                bit_depth,
+                color_primaries,
+                transfer_characteristics,
+                matrix_coefficients,
+                full_color_range: bit_reader.read_bit()?,
+                subsampling_x: true,
+                subsampling_y: true,
+                mono_chrome,
+                separate_uv_delta_q: false,
+                chroma_sample_position: 0, // CSP_UNKNOWN
+                num_planes,
+            })
+        } else {
+            let ColorRangeAndSubsampling {
+                color_range,
+                subsampling_x,
+                subsampling_y,
+            } = Self::parse_color_range_and_subsampling(
+                bit_reader,
+                seq_profile,
+                color_primaries,
+                transfer_characteristics,
+                matrix_coefficients,
+                bit_depth,
+            )?;
+
+            let chroma_sample_position = if subsampling_x && subsampling_y {
+                bit_reader.read_bits(2)? as u8
+            } else {
+                0 // CSP_UNKNOWN
+            };
+
+            let separate_uv_delta_q = bit_reader.read_bit()?;
+            Ok(ColorConfig {
+                bit_depth,
+                mono_chrome,
+                color_primaries,
+                transfer_characteristics,
+                matrix_coefficients,
+                full_color_range: color_range,
+                subsampling_x,
+                subsampling_y,
+                chroma_sample_position,
+                separate_uv_delta_q,
+                num_planes,
+            })
+        }
+    }
+}
+
 impl SequenceHeaderObu {
-    pub fn header(&self) -> &ObuHeader {
+    pub const fn header(&self) -> &ObuHeader {
         &self.header
     }
 
-    pub fn parse(header: ObuHeader, data: Bytes) -> io::Result<Self> {
-        let mut bit_reader = BitReader::new_from_slice(data);
+    pub fn parse(header: ObuHeader, reader: &mut impl io::Read) -> io::Result<Self> {
+        let mut bit_reader = BitReader::new(reader);
 
         let seq_profile = bit_reader.read_bits(3)? as u8;
         let still_picture = bit_reader.read_bit()?;
@@ -150,7 +284,7 @@ impl SequenceHeaderObu {
 
             let initial_display_delay_present_flag = bit_reader.read_bit()?;
             let operating_points_cnt_minus_1 = bit_reader.read_bits(5)? as u8;
-            for _ in 0..=operating_points_cnt_minus_1 {
+            for _ in 0..operating_points_cnt_minus_1 + 1 {
                 let idc = bit_reader.read_bits(12)? as u16;
                 let seq_level_idx = bit_reader.read_bits(5)? as u8;
                 let seq_tier = if seq_level_idx > 7 { bit_reader.read_bit()? } else { false };
@@ -194,13 +328,6 @@ impl SequenceHeaderObu {
                     initial_display_delay,
                 });
             }
-        }
-
-        if operating_points.is_empty() {
-            return Err(io::Error::new(
-                io::ErrorKind::InvalidData,
-                "seq_obu parse error: no operating points",
-            ));
         }
 
         let frame_width_bits = bit_reader.read_bits(4)? as u8 + 1;
@@ -291,110 +418,7 @@ impl SequenceHeaderObu {
         let enable_cdef = bit_reader.read_bit()?;
         let enable_restoration = bit_reader.read_bit()?;
 
-        let high_bitdepth = bit_reader.read_bit()?;
-        let bit_depth = if seq_profile == 2 && high_bitdepth {
-            if bit_reader.read_bit()? {
-                12
-            } else {
-                10
-            }
-        } else if high_bitdepth {
-            10
-        } else {
-            8
-        };
-
-        let mono_chrome = if seq_profile == 1 { false } else { bit_reader.read_bit()? };
-
-        let color_primaries;
-        let transfer_characteristics;
-        let matrix_coefficients;
-
-        let color_description_present_flag = bit_reader.read_bit()?;
-        if color_description_present_flag {
-            color_primaries = bit_reader.read_bits(8)? as u8;
-            transfer_characteristics = bit_reader.read_bits(8)? as u8;
-            matrix_coefficients = bit_reader.read_bits(8)? as u8;
-        } else {
-            color_primaries = 2; // CP_UNSPECIFIED
-            transfer_characteristics = 2; // TC_UNSPECIFIED
-            matrix_coefficients = 2; // MC_UNSPECIFIED
-        }
-
-        let num_planes = if mono_chrome { 1 } else { 3 };
-
-        let color_config;
-
-        if mono_chrome {
-            let color_range = bit_reader.read_bit()?;
-            let subsampling_x = true;
-            let subsampling_y = true;
-            color_config = ColorConfig {
-                bit_depth,
-                color_primaries,
-                transfer_characteristics,
-                matrix_coefficients,
-                full_color_range: color_range,
-                subsampling_x,
-                subsampling_y,
-                mono_chrome,
-                separate_uv_delta_q: false,
-                chroma_sample_position: 0, // CSP_UNKNOWN
-                num_planes,
-            }
-        } else {
-            let color_range;
-            let subsampling_x;
-            let subsampling_y;
-
-            // color_primarties == CP_BT_709 && transfer_characteristics == TC_SRGB &&
-            // matrix_coefficients == MC_IDENTITY
-            if color_primaries == 1 && transfer_characteristics == 13 && matrix_coefficients == 0 {
-                color_range = true;
-                subsampling_x = false;
-                subsampling_y = false;
-            } else {
-                color_range = bit_reader.read_bit()?;
-                if seq_profile == 0 {
-                    subsampling_x = true;
-                    subsampling_y = true;
-                } else if seq_profile == 1 {
-                    subsampling_x = false;
-                    subsampling_y = false;
-                } else if bit_depth == 12 {
-                    subsampling_x = bit_reader.read_bit()?;
-                    if subsampling_x {
-                        subsampling_y = bit_reader.read_bit()?;
-                    } else {
-                        subsampling_y = false;
-                    }
-                } else {
-                    subsampling_x = true;
-                    subsampling_y = false;
-                }
-            }
-
-            let chroma_sample_position = if subsampling_x && subsampling_y {
-                bit_reader.read_bits(2)? as u8
-            } else {
-                0 // CSP_UNKNOWN
-            };
-
-            let separate_uv_delta_q = bit_reader.read_bit()?;
-            color_config = ColorConfig {
-                bit_depth,
-                mono_chrome,
-                color_primaries,
-                transfer_characteristics,
-                matrix_coefficients,
-                full_color_range: color_range,
-                subsampling_x,
-                subsampling_y,
-                chroma_sample_position,
-                separate_uv_delta_q,
-                num_planes,
-            };
-        }
+        let color_config = ColorConfig::parse(seq_profile, &mut bit_reader)?;
 
         let film_grain_params_present = bit_reader.read_bit()?;
 
@@ -428,5 +452,493 @@ impl SequenceHeaderObu {
             color_config,
             film_grain_params_present,
         })
+    }
+}
+
+#[cfg(test)]
+#[cfg_attr(all(coverage_nightly, test), coverage(off))]
+mod tests {
+    use byteorder::WriteBytesExt;
+    use scuffle_bytes_util::BitWriter;
+
+    use super::*;
+    use crate::ObuType;
+
+    #[test]
+    fn test_seq_obu_parse() {
+        let obu = b"\0\0\0j\xef\xbf\xe1\xbc\x02\x19\x90\x10\x10\x10@";
+
+        let header = ObuHeader {
+            obu_type: ObuType::SequenceHeader,
+            size: None,
+            extension_header: None,
+        };
+
+        let seq_header = SequenceHeaderObu::parse(header, &mut io::Cursor::new(obu)).unwrap();
+
+        insta::assert_debug_snapshot!(seq_header, @r"
+        SequenceHeaderObu {
+            header: ObuHeader {
+                obu_type: SequenceHeader,
+                size: None,
+                extension_header: None,
+            },
+            seq_profile: 0,
+            still_picture: false,
+            reduced_still_picture_header: false,
+            timing_info: None,
+            decoder_model_info: None,
+            operating_points: [
+                OperatingPoint {
+                    idc: 0,
+                    seq_level_idx: 13,
+                    seq_tier: false,
+                    operating_parameters_info: None,
+                    initial_display_delay: None,
+                },
+            ],
+            max_frame_width: 3840,
+            max_frame_height: 2160,
+            frame_ids: None,
+            use_128x128_superblock: false,
+            enable_filter_intra: false,
+            enable_intra_edge_filter: false,
+            enable_interintra_compound: false,
+            enable_masked_compound: false,
+            enable_warped_motion: false,
+            enable_dual_filter: false,
+            enable_order_hint: true,
+            enable_jnt_comp: false,
+            enable_ref_frame_mvs: false,
+            seq_force_screen_content_tools: 0,
+            seq_force_integer_mv: 2,
+            order_hint_bits: 7,
+            enable_superres: false,
+            enable_cdef: true,
+            enable_restoration: true,
+            color_config: ColorConfig {
+                bit_depth: 8,
+                mono_chrome: false,
+                num_planes: 3,
+                color_primaries: 1,
+                transfer_characteristics: 1,
+                matrix_coefficients: 1,
+                full_color_range: false,
+                subsampling_x: true,
+                subsampling_y: true,
+                chroma_sample_position: 0,
+                separate_uv_delta_q: false,
+            },
+            film_grain_params_present: false,
+        }
+        ");
+
+        assert_eq!(seq_header.header(), &header);
+    }
+
+    #[test]
+    fn test_seq_obu_parse_reduced_still_picture() {
+        let mut bits = BitWriter::new(Vec::new());
+
+        bits.write_bits(0b010, 3).unwrap(); // seq_profile (2)
+        bits.write_bit(false).unwrap(); // still_picture
+        bits.write_bit(true).unwrap(); // reduced_still_picture_header
+        bits.write_bits(11, 5).unwrap(); // seq_lvl_idx
+
+        bits.write_bits(15, 4).unwrap();
+        bits.write_bits(15, 4).unwrap();
+        bits.write_bits(1919, 16).unwrap();
+        bits.write_bits(1079, 16).unwrap();
+
+        bits.write_bit(false).unwrap(); // use_128x128_superblock
+        bits.write_bit(false).unwrap(); // enable_filter_intra
+        bits.write_bit(false).unwrap(); // enable_intra_edge_filter
+        bits.write_bit(false).unwrap(); // enable_superres
+        bits.write_bit(false).unwrap(); // enable_cdef
+        bits.write_bit(false).unwrap(); // enable_restoration
+
+        bits.write_bit(false).unwrap(); // high_bitdepth
+        bits.write_bit(true).unwrap(); // mono_chrome
+        bits.write_bit(false).unwrap(); // color_description_present_flag
+        bits.write_bit(true).unwrap(); // color_range
+        bits.write_bit(true).unwrap(); // separate_uv_delta_q
+
+        bits.write_bit(true).unwrap(); // film_grain_params_present
+
+        let obu_header = SequenceHeaderObu::parse(
+            ObuHeader {
+                obu_type: ObuType::SequenceHeader,
+                size: None,
+                extension_header: None,
+            },
+            &mut io::Cursor::new(bits.finish().unwrap()),
+        )
+        .unwrap();
+
+        insta::assert_debug_snapshot!(obu_header, @r"
+        SequenceHeaderObu {
+            header: ObuHeader {
+                obu_type: SequenceHeader,
+                size: None,
+                extension_header: None,
+            },
+            seq_profile: 2,
+            still_picture: false,
+            reduced_still_picture_header: true,
+            timing_info: None,
+            decoder_model_info: None,
+            operating_points: [
+                OperatingPoint {
+                    idc: 0,
+                    seq_level_idx: 11,
+                    seq_tier: false,
+                    operating_parameters_info: None,
+                    initial_display_delay: None,
+                },
+            ],
+            max_frame_width: 1920,
+            max_frame_height: 1080,
+            frame_ids: None,
+            use_128x128_superblock: false,
+            enable_filter_intra: false,
+            enable_intra_edge_filter: false,
+            enable_interintra_compound: false,
+            enable_masked_compound: false,
+            enable_warped_motion: false,
+            enable_dual_filter: false,
+            enable_order_hint: false,
+            enable_jnt_comp: false,
+            enable_ref_frame_mvs: false,
+            seq_force_screen_content_tools: 2,
+            seq_force_integer_mv: 2,
+            order_hint_bits: 0,
+            enable_superres: false,
+            enable_cdef: false,
+            enable_restoration: false,
+            color_config: ColorConfig {
+                bit_depth: 8,
+                mono_chrome: true,
+                num_planes: 1,
+                color_primaries: 2,
+                transfer_characteristics: 2,
+                matrix_coefficients: 2,
+                full_color_range: true,
+                subsampling_x: true,
+                subsampling_y: true,
+                chroma_sample_position: 0,
+                separate_uv_delta_q: false,
+            },
+            film_grain_params_present: true,
+        }
+        ");
+    }
+
+    #[test]
+    fn test_seq_obu_parse_timing_info_decoder_model_preset() {
+        let mut bits = BitWriter::new(Vec::new());
+
+        bits.write_bits(0b010, 3).unwrap(); // seq_profile (2)
+        bits.write_bit(false).unwrap(); // still_picture
+        bits.write_bit(false).unwrap(); // reduced_still_picture_header
+        bits.write_bit(true).unwrap(); // timing_info_present_flag
+
+        bits.write_u32::<BigEndian>(1).unwrap(); // num_units_in_display_tick
+        bits.write_u32::<BigEndian>(1).unwrap(); // time_scale
+        bits.write_bit(false).unwrap(); // num_ticks_per_picture
+
+        bits.write_bit(true).unwrap(); // decoder_model_info_present_flag
+        bits.write_bits(4, 5).unwrap(); // buffer_delay_length
+        bits.write_u32::<BigEndian>(1).unwrap(); // num_units_in_decoding_tick
+        bits.write_bits(4, 5).unwrap(); // buffer_removal_time_length
+        bits.write_bits(4, 5).unwrap(); // frame_presentation_time_length
+
+        bits.write_bit(true).unwrap(); // initial_display_delay_present_flag
+        bits.write_bits(0, 5).unwrap(); // operating_points_cnt_minus_1
+
+        bits.write_bits(0, 12).unwrap(); // idc
+        bits.write_bits(1, 5).unwrap(); // seq_lvl_idx
+        bits.write_bit(true).unwrap(); // seq_tier
+
+        bits.write_bits(0b1010, 5).unwrap(); // decoder_buffer_delay
+        bits.write_bits(0b0101, 5).unwrap(); // encoder_buffer_delay
+        bits.write_bit(false).unwrap(); // low_delay_mode_flag
+
+        bits.write_bit(true).unwrap(); // film_grain_params_present
+        bits.write_bits(15, 4).unwrap(); // initial_display_delay_minus_1
+
+        bits.write_bits(15, 4).unwrap(); // operating_points_cnt_minus_1
+        bits.write_bits(15, 4).unwrap(); // operating_points_cnt_minus_1
+        bits.write_bits(1919, 16).unwrap(); // operating_points_cnt_minus_1
+        bits.write_bits(1079, 16).unwrap(); // operating_points_cnt_minus_1
+
+        bits.write_bit(true).unwrap(); // frame_id_numbers_present_flag
+        bits.write_bits(0b1101, 4).unwrap(); // delta_frame_id_length
+        bits.write_bits(0b101, 3).unwrap(); // additional_frame_id_length
+
+        bits.write_bit(false).unwrap(); // use_128x128_superblock
+        bits.write_bit(false).unwrap(); // enable_filter_intra
+        bits.write_bit(false).unwrap(); // enable_intra_edge_filter
+
+        bits.write_bit(false).unwrap(); // enable_interintra_compound
+        bits.write_bit(false).unwrap(); // enable_masked_compound
+        bits.write_bit(false).unwrap(); // enable_warped_motion
+        bits.write_bit(false).unwrap(); // enable_dual_filter
+        bits.write_bit(true).unwrap(); // enable_order_hint
+        bits.write_bit(false).unwrap(); // enable_jnt_comp
+        bits.write_bit(false).unwrap(); // enable_ref_frame_mvs
+
+        bits.write_bit(false).unwrap();
+        bits.write_bit(true).unwrap();
+        bits.write_bit(false).unwrap();
+        bits.write_bit(false).unwrap();
+
+        bits.write_bits(0b100, 3).unwrap();
+
+        bits.write_bit(false).unwrap(); // enable_superres
+        bits.write_bit(false).unwrap(); // enable_cdef
+        bits.write_bit(false).unwrap(); // enable_restoration
+
+        bits.write_bit(false).unwrap(); // high_bitdepth
+        bits.write_bit(true).unwrap(); // mono_chrome
+        bits.write_bit(false).unwrap(); // color_description_present_flag
+        bits.write_bit(true).unwrap(); // color_range
+        bits.write_bit(true).unwrap(); // separate_uv_delta_q
+
+        bits.write_bit(true).unwrap(); // film_grain_params_present
+
+        let obu_header = SequenceHeaderObu::parse(
+            ObuHeader {
+                obu_type: ObuType::SequenceHeader,
+                size: None,
+                extension_header: None,
+            },
+            &mut io::Cursor::new(bits.finish().unwrap()),
+        )
+        .unwrap();
+
+        insta::assert_debug_snapshot!(obu_header, @r"
+        SequenceHeaderObu {
+            header: ObuHeader {
+                obu_type: SequenceHeader,
+                size: None,
+                extension_header: None,
+            },
+            seq_profile: 2,
+            still_picture: false,
+            reduced_still_picture_header: false,
+            timing_info: Some(
+                TimingInfo {
+                    num_units_in_display_tick: 1,
+                    time_scale: 1,
+                    num_ticks_per_picture: None,
+                },
+            ),
+            decoder_model_info: Some(
+                DecoderModelInfo {
+                    buffer_delay_length: 5,
+                    num_units_in_decoding_tick: 1,
+                    buffer_removal_time_length: 5,
+                    frame_presentation_time_length: 5,
+                },
+            ),
+            operating_points: [
+                OperatingPoint {
+                    idc: 0,
+                    seq_level_idx: 1,
+                    seq_tier: false,
+                    operating_parameters_info: Some(
+                        OperatingParametersInfo {
+                            decoder_buffer_delay: 10,
+                            encoder_buffer_delay: 5,
+                            low_delay_mode_flag: false,
+                        },
+                    ),
+                    initial_display_delay: Some(
+                        16,
+                    ),
+                },
+            ],
+            max_frame_width: 1920,
+            max_frame_height: 1080,
+            frame_ids: Some(
+                FrameIds {
+                    delta_frame_id_length: 15,
+                    additional_frame_id_length: 6,
+                },
+            ),
+            use_128x128_superblock: false,
+            enable_filter_intra: false,
+            enable_intra_edge_filter: false,
+            enable_interintra_compound: false,
+            enable_masked_compound: false,
+            enable_warped_motion: false,
+            enable_dual_filter: false,
+            enable_order_hint: true,
+            enable_jnt_comp: false,
+            enable_ref_frame_mvs: false,
+            seq_force_screen_content_tools: 1,
+            seq_force_integer_mv: 0,
+            order_hint_bits: 5,
+            enable_superres: false,
+            enable_cdef: false,
+            enable_restoration: false,
+            color_config: ColorConfig {
+                bit_depth: 8,
+                mono_chrome: true,
+                num_planes: 1,
+                color_primaries: 2,
+                transfer_characteristics: 2,
+                matrix_coefficients: 2,
+                full_color_range: true,
+                subsampling_x: true,
+                subsampling_y: true,
+                chroma_sample_position: 0,
+                separate_uv_delta_q: false,
+            },
+            film_grain_params_present: true,
+        }
+        ");
+    }
+
+    #[test]
+    fn test_seq_obu_parse_color_range_and_subsampling() {
+        let mut bits = BitWriter::new(Vec::new());
+
+        bits.write_bit(false).unwrap(); // color_range
+        bits.write_bit(false).unwrap(); // subsampling_x
+        bits.write_bit(false).unwrap(); // subsampling_y
+
+        let color_range_and_subsampling = ColorConfig::parse_color_range_and_subsampling(
+            &mut BitReader::new(std::io::Cursor::new(Vec::new())),
+            0,
+            1,
+            13,
+            0,
+            8,
+        )
+        .unwrap();
+
+        assert_eq!(
+            color_range_and_subsampling,
+            ColorRangeAndSubsampling {
+                color_range: true,
+                subsampling_x: false,
+                subsampling_y: false,
+            }
+        );
+
+        let color_range_and_subsampling = ColorConfig::parse_color_range_and_subsampling(
+            &mut BitReader::new(std::io::Cursor::new(&[0b10000000])),
+            0,
+            1,
+            0,
+            0,
+            8,
+        )
+        .unwrap();
+
+        assert_eq!(
+            color_range_and_subsampling,
+            ColorRangeAndSubsampling {
+                color_range: true,
+                subsampling_x: true,
+                subsampling_y: true,
+            }
+        );
+
+        let color_range_and_subsampling = ColorConfig::parse_color_range_and_subsampling(
+            &mut BitReader::new(std::io::Cursor::new(&[0b10000000])),
+            1,
+            1,
+            0,
+            0,
+            8,
+        )
+        .unwrap();
+
+        assert_eq!(
+            color_range_and_subsampling,
+            ColorRangeAndSubsampling {
+                color_range: true,
+                subsampling_x: false,
+                subsampling_y: false,
+            }
+        );
+
+        let color_range_and_subsampling = ColorConfig::parse_color_range_and_subsampling(
+            &mut BitReader::new(std::io::Cursor::new(&[0b11100000])),
+            2,
+            1,
+            0,
+            0,
+            12,
+        )
+        .unwrap();
+
+        assert_eq!(
+            color_range_and_subsampling,
+            ColorRangeAndSubsampling {
+                color_range: true,
+                subsampling_x: true,
+                subsampling_y: true,
+            }
+        );
+
+        let color_range_and_subsampling = ColorConfig::parse_color_range_and_subsampling(
+            &mut BitReader::new(std::io::Cursor::new(&[0b11000000])),
+            2,
+            1,
+            0,
+            0,
+            12,
+        )
+        .unwrap();
+
+        assert_eq!(
+            color_range_and_subsampling,
+            ColorRangeAndSubsampling {
+                color_range: true,
+                subsampling_x: true,
+                subsampling_y: false,
+            }
+        );
+
+        let color_range_and_subsampling = ColorConfig::parse_color_range_and_subsampling(
+            &mut BitReader::new(std::io::Cursor::new(&[0b10100000])),
+            2,
+            1,
+            0,
+            0,
+            12,
+        )
+        .unwrap();
+
+        assert_eq!(
+            color_range_and_subsampling,
+            ColorRangeAndSubsampling {
+                color_range: true,
+                subsampling_x: false,
+                subsampling_y: false,
+            }
+        );
+
+        let color_range_and_subsampling = ColorConfig::parse_color_range_and_subsampling(
+            &mut BitReader::new(std::io::Cursor::new(&[0b11100000])),
+            2,
+            1,
+            0,
+            0,
+            8,
+        )
+        .unwrap();
+
+        assert_eq!(
+            color_range_and_subsampling,
+            ColorRangeAndSubsampling {
+                color_range: true,
+                subsampling_x: true,
+                subsampling_y: false,
+            }
+        );
     }
 }

--- a/crates/av1/src/obu/utils.rs
+++ b/crates/av1/src/obu/utils.rs
@@ -1,0 +1,64 @@
+use std::io;
+
+use scuffle_bytes_util::BitReader;
+
+/// Read a little-endian variable-length integer.
+/// AV1-Spec-2 - 4.10.5
+pub fn read_leb128<T: io::Read>(reader: &mut BitReader<T>) -> io::Result<u64> {
+    let mut result = 0;
+    for i in 0..8 {
+        let byte = reader.read_bits(8)?;
+        result |= (byte & 0x7f) << (i * 7);
+        if byte & 0x80 == 0 {
+            break;
+        }
+    }
+    Ok(result)
+}
+
+/// Read a variable-length unsigned integer.
+/// AV1-Spec-2 - 4.10.3
+pub fn read_uvlc<T: io::Read>(reader: &mut BitReader<T>) -> io::Result<u64> {
+    let mut leading_zeros = 0;
+    while !reader.read_bit()? {
+        leading_zeros += 1;
+    }
+
+    if leading_zeros >= 32 {
+        return Ok((1 << 32) - 1);
+    }
+
+    let value = reader.read_bits(leading_zeros)?;
+    Ok(value + (1 << leading_zeros) - 1)
+}
+
+#[cfg(test)]
+#[cfg_attr(all(test, coverage_nightly), coverage(off))]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_read_leb128() {
+        let mut cursor = std::io::Cursor::new([0b11010101, 0b00101010]);
+        let mut reader = BitReader::new(&mut cursor);
+        assert_eq!(read_leb128(&mut reader).unwrap(), 0b1010101010101);
+
+        let mut cursor = std::io::Cursor::new([0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff]);
+        let mut reader = BitReader::new(&mut cursor);
+
+        // 8 bits less because we lose 1 bit from each byte with 8 bytes this means the
+        // max we can read is 2^56 - 1
+        assert_eq!(read_leb128(&mut reader).unwrap(), (1 << 56) - 1);
+    }
+
+    #[test]
+    fn test_read_uvlc() {
+        let mut cursor = std::io::Cursor::new([0x01, 0xff]);
+        let mut reader = BitReader::new(&mut cursor);
+        assert_eq!(read_uvlc(&mut reader).unwrap(), 0xfe);
+
+        let mut cursor = std::io::Cursor::new([0x00, 0x00, 0x00, 0x00, 0x01]);
+        let mut reader = BitReader::new(&mut cursor);
+        assert_eq!(read_uvlc(&mut reader).unwrap(), (1 << 32) - 1);
+    }
+}

--- a/crates/flv/Cargo.toml
+++ b/crates/flv/Cargo.toml
@@ -10,7 +10,7 @@ bytes = "1.5"
 num-traits = "0.2"
 num-derive = "0.4"
 
-av1 = { path = "../av1" }
+scuffle-av1.workspace = true
 h264 = { path = "../h264" }
 h265 = { path = "../h265" }
 scuffle-aac = { path = "../aac" }

--- a/crates/flv/src/define.rs
+++ b/crates/flv/src/define.rs
@@ -1,9 +1,9 @@
-use av1::AV1CodecConfigurationRecord;
 use bytes::Bytes;
 use h264::AVCDecoderConfigurationRecord;
 use h265::HEVCDecoderConfigurationRecord;
 use num_derive::FromPrimitive;
 use scuffle_amf0::Amf0Value;
+use scuffle_av1::AV1CodecConfigurationRecord;
 
 #[derive(Debug, Clone, PartialEq)]
 /// FLV File

--- a/crates/flv/src/flv.rs
+++ b/crates/flv/src/flv.rs
@@ -2,13 +2,13 @@ use std::io::{
     Read, {self},
 };
 
-use av1::AV1CodecConfigurationRecord;
 use byteorder::{BigEndian, ReadBytesExt};
 use bytes::{Buf, Bytes};
 use h264::AVCDecoderConfigurationRecord;
 use h265::HEVCDecoderConfigurationRecord;
 use num_traits::FromPrimitive;
 use scuffle_amf0::{Amf0Decoder, Amf0Value};
+use scuffle_av1::AV1CodecConfigurationRecord;
 use scuffle_bytes_util::BytesCursorExt;
 
 use crate::define::Flv;

--- a/crates/flv/src/tests/demuxer.rs
+++ b/crates/flv/src/tests/demuxer.rs
@@ -483,7 +483,6 @@ fn test_demux_flv_av1_aac() {
             _ => panic!("expected av1 sequence header found {:?}", video_data),
         };
 
-        assert_eq!(config.version, 1);
         assert_eq!(config.chroma_sample_position, 0);
         assert!(config.chroma_subsampling_x); // 5.1
         assert!(config.chroma_subsampling_y);

--- a/crates/mp4/Cargo.toml
+++ b/crates/mp4/Cargo.toml
@@ -12,7 +12,7 @@ paste = "1.0"
 
 h264 = { path = "../h264" }
 h265 = { path = "../h265" }
-av1 = { path = "../av1" }
+scuffle-av1.workspace = true
 scuffle-aac = { path = "../aac" }
 scuffle-bytes-util.workspace = true
 scuffle-workspace-hack.workspace = true

--- a/crates/mp4/src/boxes/types/av1c.rs
+++ b/crates/mp4/src/boxes/types/av1c.rs
@@ -1,7 +1,7 @@
 use std::io;
 
-use av1::AV1CodecConfigurationRecord;
 use bytes::Bytes;
+use scuffle_av1::AV1CodecConfigurationRecord;
 
 use crate::boxes::header::BoxHeader;
 use crate::boxes::traits::BoxType;

--- a/crates/mp4/src/tests/demux.rs
+++ b/crates/mp4/src/tests/demux.rs
@@ -4,11 +4,11 @@ use std::io::{
 use std::path::PathBuf;
 use std::process::{Command, Stdio};
 
-use av1::AV1CodecConfigurationRecord;
 use bytes::{Buf, Bytes};
 use fixed::FixedI32;
 use h264::AVCDecoderConfigurationRecord;
 use h265::{HEVCDecoderConfigurationRecord, NaluArray, NaluType};
+use scuffle_av1::AV1CodecConfigurationRecord;
 
 use crate::boxes::header::{BoxHeader, FullBoxHeader};
 use crate::boxes::types::avc1::Avc1;

--- a/crates/mp4/src/tests/demux.rs
+++ b/crates/mp4/src/tests/demux.rs
@@ -1201,8 +1201,6 @@ fn test_demux_av1_aac() {
                         av1c: Av1C {
                             header: BoxHeader { box_type: *b"av1C" },
                             av1_config: AV1CodecConfigurationRecord {
-                                marker: true,
-                                version: 1,
                                 seq_profile: 0,
                                 seq_level_idx_0: 4,
                                 seq_tier_0: false,

--- a/crates/transmuxer/Cargo.toml
+++ b/crates/transmuxer/Cargo.toml
@@ -10,7 +10,7 @@ bytes = "1.5"
 
 h264 = { path = "../h264" }
 h265 = { path = "../h265" }
-av1 = { path = "../av1" }
+scuffle-av1.workspace = true
 scuffle-aac = { path = "../aac" }
 scuffle-amf0.workspace = true
 flv = { path = "../flv" }

--- a/crates/transmuxer/src/define.rs
+++ b/crates/transmuxer/src/define.rs
@@ -1,9 +1,9 @@
-use av1::AV1CodecConfigurationRecord;
 use bytes::Bytes;
 use flv::{SoundSize, SoundType};
 use h264::AVCDecoderConfigurationRecord;
 use h265::HEVCDecoderConfigurationRecord;
 use mp4::codec::{AudioCodec, VideoCodec};
+use scuffle_av1::AV1CodecConfigurationRecord;
 
 pub(crate) enum VideoSequenceHeader {
     Avc(AVCDecoderConfigurationRecord),


### PR DESCRIPTION
Moves av1 stuff into a new crate for av1 decoding, encoding & obu parsing. 

Improves test coverage on existing av1 parsing.

Improves parse design making use of zero copy behaviour. 

Remove `scuffle_bytes_util::BytesCursorExt::remaining()` fn because it conflicts with an already existing more generic impl from `Bytes::Buf`.

CLOUD-25