### PR TITLE
docs: clean up

### DIFF
--- a/crates/aac/src/lib.rs
+++ b/crates/aac/src/lib.rs
@@ -1,5 +1,3 @@
-//! # scuffle-aac
-//!
 //! A crate for decoding AAC audio headers.
 //!
 //! ## License

--- a/crates/av1/src/lib.rs
+++ b/crates/av1/src/lib.rs
@@ -1,7 +1,3 @@
-//! # scuffle-av1
-//!
-//! [![crates.io](https://img.shields.io/crates/v/scuffle-av1.svg)](https://crates.io/crates/scuffle-av1) [![docs.rs](https://img.shields.io/docsrs/scuffle-av1)](https://docs.rs/scuffle-av1)
-//!
 //! A crate for decoding and encoding AV1 video headers.
 //!
 //! ## License

--- a/crates/batching/src/lib.rs
+++ b/crates/batching/src/lib.rs
@@ -1,5 +1,3 @@
-//! # scuffle-batching
-//!
 //! A crate designed to batch multiple requests into a single request.
 //!
 //! ## Why do we need this?

--- a/crates/bootstrap/src/lib.rs
+++ b/crates/bootstrap/src/lib.rs
@@ -1,5 +1,3 @@
-//! # scuffle-bootstrap
-//!
 //! A utility crate for creating binaries.
 //!
 //! Refer to [`Global`], [`Service`], and [`main`] for more information.

--- a/crates/bootstrap/telemetry/src/lib.rs
+++ b/crates/bootstrap/telemetry/src/lib.rs
@@ -1,5 +1,3 @@
-//! # scuffle-bootstrap-telemetry
-//!
 //! A crate used to add telemetry to applications built with the
 //! [`scuffle-bootstrap`](../scuffle_bootstrap) crate.
 //!

--- a/crates/context/src/lib.rs
+++ b/crates/context/src/lib.rs
@@ -1,5 +1,3 @@
-//! # scuffle-context
-//!
 //! A crate designed to provide the ability to cancel futures using a context
 //! go-like approach, allowing for graceful shutdowns and cancellations.
 //!

--- a/crates/expgolomb/src/lib.rs
+++ b/crates/expgolomb/src/lib.rs
@@ -1,5 +1,3 @@
-//! # scuffle-expgolomb
-//!
 //! A set of helper functions to encode and decode exponential-golomb values.
 //!
 //! This crate extends upon the [`BitReader`] and [`BitWriter`] from the

--- a/crates/flv/src/lib.rs
+++ b/crates/flv/src/lib.rs
@@ -1,5 +1,3 @@
-//! # scuffle-flv
-//!
 //! A pure Rust implementation of the FLV format, allowing for demuxing of FLV
 //! files or streams.
 //!

--- a/crates/metrics/derive/src/lib.rs
+++ b/crates/metrics/derive/src/lib.rs
@@ -1,5 +1,3 @@
-//! # scuffle-metrics-derive
-//!
 //! A proc-macro to derive the `#[metrics]` attribute and the
 //! `#[derive(MetricEnum)]` attribute.
 //!

--- a/crates/metrics/src/lib.rs
+++ b/crates/metrics/src/lib.rs
@@ -1,5 +1,3 @@
-//! # scuffle-metrics
-//!
 //! A wrapper around opentelemetry to provide a more ergonomic interface for
 //! creating metrics.
 //!

--- a/crates/signal/src/lib.rs
+++ b/crates/signal/src/lib.rs
@@ -1,5 +1,3 @@
-//! # scuffle-signal
-//!
 //! A crate designed to provide a more user friendly interface to
 //! `tokio::signal`.
 //!


### PR DESCRIPTION
- Removes headlines from crate root docs

Otherwise it would look like this when rendered:

![headline shows twice](https://github.com/user-attachments/assets/f1decb6c-66fb-4aa6-acb4-365539eca77d)

CLOUD-35
<!--
Thank you for your Pull Request. Please provide a short description of your changes above.

Bug fixes and new features should include tests.

Contributors guide: https://github.com/ScuffleCloud/.github/blob/main/CONTRIBUTING.md
-->
