### PR TITLE
fix path for workspace hack dep

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -61,7 +61,7 @@ postcompile = { path = "crates/postcompile", version = "0.0.5" }
 scuffle-pprof = { path = "crates/pprof", version = "0.0.2" }
 scuffle-settings = { path = "crates/settings", version = "0.0.2" }
 scuffle-signal = { path = "crates/signal", version = "0.0.2" }
-scuffle-workspace-hack = { path = "crates/workspace-hack", version = "0.1.0" }
+scuffle-workspace-hack = { version = "0.1.0" }
 
 # To be renamed:
 # scuffle-h264 = { path = "crates/h264", version = "0.0.1" }


### PR DESCRIPTION
This is a small fix that allows this crate to be used correctly via a git dep.
