### PR TITLE
disable code cov status check

### DIFF
--- a/codecov.yml
+++ b/codecov.yml
@@ -1,9 +1,7 @@
 coverage:
   status:
-    project:
-      default:
-        target: auto
-        threshold: 10%
+    project: off
+    patch: off
 
 github_checks:
   annotations: false


### PR DESCRIPTION
We dont need codecov to fail a commit if the coverage doesnt meet the thresholds.
