### PR TITLE
updated readme github actions badge

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,7 +24,7 @@
 <p align="center">
     <a href="https://codecov.io/gh/ScuffleCloud/scuffle"><img height="30" src="https://img.shields.io/codecov/c/github/ScuffleCloud/scuffle?logo=codecov&token=LJCYSZR4IV&style=for-the-badge"/></a>
     &nbsp;
-    <a href="https://github.com/ScuffleCloud/scuffle/actions"><img height="30" src="https://img.shields.io/github/checks-status/ScuffleCloud/scuffle/main?style=for-the-badge&logo=githubactions&logoColor=white"/></a>
+    <a href="https://github.com/ScuffleCloud/scuffle/actions?query=branch%3Amain"><img height="30" src="https://img.shields.io/github/check-runs/ScuffleCloud/Scuffle/main?style=for-the-badge&logo=githubactions&logoColor=white"/></a>
 </p>
 
 > [!WARNING]  


### PR DESCRIPTION
Updates Github Actions status checks badge to be correct. Note that this also changes the behavior of clicking the icon to link to checks of specifically the main branch.

Previous appearance:

![image](https://github.com/user-attachments/assets/a6a8b558-fd11-4efb-b751-75ef11417c75)

Fixed appearance:

![image](https://github.com/user-attachments/assets/83c24309-6276-4987-ad01-5241529a9044)

Also the updated version allows for checking specific check runs if we want to use that in the future: https://shields.io/badges/git-hub-branch-check-runs

![image](https://github.com/user-attachments/assets/03f23d1e-0fd2-42e4-b211-02ef7f595777)
