### PR TITLE
fix: memory leaks in ffmpeg tests

### DIFF
--- a/crates/ffmpeg/src/decoder.rs
+++ b/crates/ffmpeg/src/decoder.rs
@@ -478,11 +478,17 @@ mod tests {
         let mut input = Input::open(valid_file_path).expect("Failed to open valid file");
         let mut streams = input.streams_mut();
         let mut stream = streams.get(0).expect("Expected a valid stream");
+        // Safety: Stream is a valid pointer.
+        let codecpar = unsafe { (*stream.as_mut_ptr()).codecpar };
         // Safety: We are setting the `codecpar` to `null` to simulate a missing codec parameters.
         unsafe {
             (*stream.as_mut_ptr()).codecpar = std::ptr::null_mut();
         }
         let decoder_result = Decoder::with_options(&stream, DecoderOptions::default());
+        // Safety: Stream is a valid pointer.
+        unsafe {
+            (*stream.as_mut_ptr()).codecpar = codecpar;
+        }
 
         assert!(decoder_result.is_err(), "Expected Decoder creation to fail");
         if let Err(err) = decoder_result {

--- a/crates/ffmpeg/src/log.rs
+++ b/crates/ffmpeg/src/log.rs
@@ -220,6 +220,7 @@ mod tests {
         assert_eq!(*level, LogLevel::Warning, "Expected log level to be Warning");
         assert!(class.is_none(), "Expected class to be None for this test");
         assert_eq!(message, "Test warning log message", "Expected log message to match");
+        log_callback_unset();
     }
 
     #[test]
@@ -256,6 +257,7 @@ mod tests {
         assert_eq!(*level, LogLevel::Info, "Expected log level to be Info");
         assert!(class.is_some(), "Expected class name to be captured");
         assert_eq!(message, "Test log message with real AVClass", "Expected log message to match");
+        log_callback_unset();
     }
 
     #[test]
@@ -356,6 +358,7 @@ mod tests {
                 expected_message
             );
         }
+        log_callback_unset();
     }
 
     #[cfg(feature = "tracing")]
@@ -387,5 +390,6 @@ mod tests {
             "Expected log message for '{}'",
             deprecated_message
         );
+        log_callback_unset();
     }
 }


### PR DESCRIPTION
Fixes 2 memory leaks in unit tests.

found using:

`CARGO_TARGET_X86_64_UNKNOWN_LINUX_GNU_RUNNER="valgrind --error-exitcode=1 --leak-check=full" cargo nextest run -p scuffle-ffmpeg`

Rust does not run destructors of static variables therefore we need to manually unset the log callbacks when we add them.

<!--
Thank you for your Pull Request. Please provide a short description of your changes above.

Bug fixes and new features should include tests.

Contributors guide: https://github.com/ScuffleCloud/.github/blob/main/CONTRIBUTING.md
-->
