### PR TITLE
fix windows for ffmpeg build

### DIFF
--- a/crates/ffmpeg/CHANGELOG.md
+++ b/crates/ffmpeg/CHANGELOG.md
@@ -7,6 +7,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+- Fixed windows build (#238)
+
 ## [0.1.2](https://github.com/ScuffleCloud/scuffle/compare/scuffle-ffmpeg-v0.1.1...scuffle-ffmpeg-v0.1.2) - 2025-02-10
 
 ## [0.1.1](https://github.com/ScuffleCloud/scuffle/compare/scuffle-ffmpeg-v0.1.0...scuffle-ffmpeg-v0.1.1) - 2025-02-10

--- a/crates/ffmpeg/src/log.rs
+++ b/crates/ffmpeg/src/log.rs
@@ -84,7 +84,18 @@ pub fn log_callback_unset() {
     }
 }
 
-unsafe extern "C" fn log_cb(ptr: *mut libc::c_void, level: libc::c_int, fmt: *const libc::c_char, va: *mut __va_list_tag) {
+#[cfg(unix)]
+type VaList = *mut __va_list_tag;
+
+#[cfg(windows)]
+type VaList = va_list;
+
+#[cfg(windows)]
+extern "C" {
+    fn vsnprintf(buffer: *mut libc::c_char, count: libc::size_t, format: *const libc::c_char, ap: VaList) -> i32;
+}
+
+unsafe extern "C" fn log_cb(ptr: *mut libc::c_void, level: libc::c_int, fmt: *const libc::c_char, va: VaList) {
     let level = LogLevel::from(level);
     let class = NonNull::new(ptr as *mut *mut AVClass)
         .and_then(|class| NonNull::new(*class.as_ptr()))

--- a/crates/ffmpeg/src/scaler.rs
+++ b/crates/ffmpeg/src/scaler.rs
@@ -1,4 +1,6 @@
 use ffmpeg_sys_next::*;
+#[cfg(windows)]
+use SwsFlags::*;
 
 use crate::error::{FfmpegError, FfmpegErrorCode};
 use crate::frame::{Frame, VideoFrame};
@@ -35,7 +37,7 @@ impl Scaler {
                 width,
                 height,
                 pixel_format,
-                SWS_BILINEAR,
+                SWS_BILINEAR as i32,
                 std::ptr::null_mut(),
                 std::ptr::null_mut(),
                 std::ptr::null(),


### PR DESCRIPTION
fixes #282 

This build fixes the small issues with the windows build for ffmpeg. We don't officially support windows builds on any of our crates yet. That will not be done in this PR, there is a more compressive ticket for that CLOUD-58.

We do not officially support windows, we don't run tests / memory checks against our libraries on windows. Therefore even though it compiles safety is not guaranteed. After CLOUD-58 is completed we can assert that windows is correct.