### PR TITLE
CI Improvements

### DIFF
--- a/.github/actions/setup-ffmpeg/action.yaml
+++ b/.github/actions/setup-ffmpeg/action.yaml
@@ -1,0 +1,24 @@
+name: Setup FFmpeg
+description: Installs FFmpeg on the system
+runs:
+  using: "composite"
+  steps:
+    - name: Install System Dependencies
+      run: |
+        set -xeo pipefail
+        sudo apt-get update
+        sudo apt-get install -y --no-install-recommends libdrm2 libxcb1 libasound2t64 libxv1 libc++1 libvdpau1 libva2 nasm libx264-dev
+
+    - name: Install ffmpeg
+      run: |
+        set -xeo pipefail
+
+        curl -L https://sourceforge.net/projects/avbuild/files/linux/ffmpeg-7.1-linux-clang-default.tar.xz/download -o ffmpeg.tar.xz
+        tar -xvf ffmpeg.tar.xz
+
+        sudo mv ffmpeg-7.1-linux-clang-default/include/* /usr/include
+        sudo mv ffmpeg-7.1-linux-clang-default/lib/amd64/* /usr/local/lib
+        sudo mv ffmpeg-7.1-linux-clang-default/bin/amd64/* /usr/local/bin
+        sudo rm -rf ffmpeg-7.1-linux-clang-default
+        sudo rm -rf ffmpeg.tar.xz
+        sudo ldconfig

--- a/.github/actions/setup-ffmpeg/action.yaml
+++ b/.github/actions/setup-ffmpeg/action.yaml
@@ -4,12 +4,14 @@ runs:
   using: "composite"
   steps:
     - name: Install System Dependencies
+      shell: bash
       run: |
         set -xeo pipefail
         sudo apt-get update
         sudo apt-get install -y --no-install-recommends libdrm2 libxcb1 libasound2t64 libxv1 libc++1 libvdpau1 libva2 nasm libx264-dev
 
     - name: Install ffmpeg
+      shell: bash
       run: |
         set -xeo pipefail
 

--- a/.github/actions/setup-ffmpeg/action.yaml
+++ b/.github/actions/setup-ffmpeg/action.yaml
@@ -8,7 +8,16 @@ runs:
       run: |
         set -xeo pipefail
         sudo apt-get update
-        sudo apt-get install -y --no-install-recommends libdrm2 libxcb1 libasound2t64 libxv1 libc++1 libvdpau1 libva2 nasm libx264-dev
+        sudo apt-get install -y --no-install-recommends \
+          libdrm2 \
+          libxcb1 \
+          libasound2t64 \
+          libxv1 \
+          libc++1 \
+          libvdpau1 \
+          libva2 \
+          libx264-dev \
+          nasm
 
     - name: Install ffmpeg
       shell: bash

--- a/.github/actions/setup-rust/action.yaml
+++ b/.github/actions/setup-rust/action.yaml
@@ -1,0 +1,18 @@
+name: Brawl Override
+description: Get the correct PR / Commit SHA when running brawl
+outputs:
+  pr-number:
+    description: "The PR number"
+  commit-sha:
+    description: "The commit SHA"
+runs:
+  using: "composite"
+  steps:
+    - name: Brawl Override
+      id: brawl-override
+      if: ${{ startsWith(github.ref, 'refs/heads/automation/brawl/try/') }}
+      run: |
+        PR_NUMBER=$(echo ${{ github.ref }} | sed -n 's/^refs\/heads\/automation\/brawl\/try\/\([0-9]*\)$/\1/p')
+        echo "PR_NUMBER=$PR_NUMBER" >> $GITHUB_ENV
+        RUN_COMMIT_SHA=$(git log -1 --pretty=format:%H)
+        echo "RUN_COMMIT_SHA=$RUN_COMMIT_SHA" >> $GITHUB_ENV

--- a/.github/actions/setup-rust/action.yaml
+++ b/.github/actions/setup-rust/action.yaml
@@ -1,19 +1,35 @@
-name: Brawl Override
-description: Get the correct PR / Commit SHA when running brawl
-outputs:
-  pr-number:
-    description: "The PR number"
-  commit-sha:
-    description: "The commit SHA"
+name: Setup Rust
+description: Configures the Rust toolchain
+inputs:
+  toolchain:
+    description: "The toolchain to use"
+    required: true
+    default: "stable"
+  components:
+    description: "The components to install"
+    required: false
+  shared-key:
+    description: "The key to use for the shared cache"
+    required: false
+  tools:
+    description: "The tools to install"
+    required: false
 runs:
   using: "composite"
   steps:
-    - name: Brawl Override
-      id: brawl-override
-      if: ${{ startsWith(github.ref, 'refs/heads/automation/brawl/try/') }}
-      shell: bash
-      run: |
-        PR_NUMBER=$(echo ${{ github.ref }} | sed -n 's/^refs\/heads\/automation\/brawl\/try\/\([0-9]*\)$/\1/p')
-        echo "PR_NUMBER=$PR_NUMBER" >> $GITHUB_ENV
-        RUN_COMMIT_SHA=$(git log -1 --pretty=format:%H)
-        echo "RUN_COMMIT_SHA=$RUN_COMMIT_SHA" >> $GITHUB_ENV
+    - uses: dtolnay/rust-toolchain@stable
+      id: setup-rust
+      with:
+        toolchain: ${{ inputs.toolchain }}
+        components: ${{ inputs.components }}
+
+    - uses: Swatinem/rust-cache@v2
+      if: ${{ inputs.shared-key }}
+      with:
+        prefix-key: "v0-rust-${{ steps.setup-rust.outputs.cachekey }}"
+        shared-key: ${{ inputs.shared-key }}
+
+    - uses: taiki-e/install-action@v2
+      if: ${{ inputs.tools }}
+      with:
+        tool: ${{ inputs.tools }}

--- a/.github/actions/setup-rust/action.yaml
+++ b/.github/actions/setup-rust/action.yaml
@@ -11,6 +11,7 @@ runs:
     - name: Brawl Override
       id: brawl-override
       if: ${{ startsWith(github.ref, 'refs/heads/automation/brawl/try/') }}
+      shell: bash
       run: |
         PR_NUMBER=$(echo ${{ github.ref }} | sed -n 's/^refs\/heads\/automation\/brawl\/try\/\([0-9]*\)$/\1/p')
         echo "PR_NUMBER=$PR_NUMBER" >> $GITHUB_ENV

--- a/.github/patch-docs.sh
+++ b/.github/patch-docs.sh
@@ -3,8 +3,8 @@ set -eo pipefail
 
 repo_url=$1
 commit_hash=$2
-short_commit_hash=$3
-pull_request_number=${4:-}
+short_commit_hash=$(echo $2 | cut -c 1-7)
+pull_request_number=${3:-}
 
 pull_request_code=""
 if [ -n "$pull_request_number" ]; then

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -43,14 +43,14 @@ jobs:
         if: ${{ github.event_name == 'push' }}
         run: cargo hakari disable
 
-      - name: Make sure code is linted
+      - name: Run Clippy
         if: ${{ github.event_name == 'pull_request' }}
         run: |
           set -xeo pipefail
           export RUSTFLAGS="-Dwarnings"
           cargo +${{ env.RUST_TOOLCHAIN }} clippy -Z unstable-options --all-features --all-targets --no-deps
 
-      - name: Make sure code is linted
+      - name: Run Clippy on Powerset
         if: ${{ github.event_name == 'push' }}
         run: |
           set -xeo pipefail
@@ -268,7 +268,7 @@ jobs:
       - name: Disable Hakari
         run: cargo hakari disable
 
-      - name: Run Powerset
+      - name: Run Cargo Package on Powerset
         run: just powerset package -- --allow-dirty
 
   brawl-done:

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -28,26 +28,16 @@ jobs:
         with:
           ref: ${{ env.SHA }}
 
-      - name: Setup system deps
-        run: |
-          set -xeo pipefail
-          sudo apt-get update
-          sudo apt-get install -y --no-install-recommends nasm libx264-dev
+      - name: Setup FFmpeg
+        uses: ./.github/actions/setup-ffmpeg
 
-      - uses: dtolnay/rust-toolchain@stable
-        id: setup-rust
+      - name: Setup Rust
+        uses: ./.github/actions/setup-rust
         with:
           toolchain: ${{ env.RUST_TOOLCHAIN }}
           components: clippy
-
-      - uses: Swatinem/rust-cache@v2
-        with:
-          prefix-key: "v0-rust-${{ steps.setup-rust.outputs.cachekey }}"
           shared-key: clippy
-
-      - uses: taiki-e/install-action@v2
-        with:
-          tool: just,cargo-hakari
+          tools: just,cargo-hakari
 
       - name: Disable Hakari
         if: ${{ github.event_name == 'push' }}
@@ -71,8 +61,8 @@ jobs:
         with:
           ref: ${{ env.SHA }}
 
-      - uses: dtolnay/rust-toolchain@stable
-        id: setup-rust
+      - name: Setup Rust
+        uses: ./.github/actions/setup-rust
         with:
           toolchain: ${{ env.RUST_TOOLCHAIN }}
           components: rustfmt
@@ -88,14 +78,11 @@ jobs:
         with:
           ref: ${{ env.SHA }}
 
-      - uses: dtolnay/rust-toolchain@stable
-        id: setup-rust
+      - name: Setup Rust
+        uses: ./.github/actions/setup-rust
         with:
           toolchain: ${{ env.RUST_TOOLCHAIN }}
-
-      - uses: taiki-e/install-action@v2
-        with:
-          tool: cargo-hakari
+          tools: cargo-hakari
 
       - name: Make sure Hakari is up-to-date
         run: |
@@ -113,40 +100,16 @@ jobs:
         with:
           ref: ${{ env.SHA }}
 
-      - name: Setup system deps
-        run: |
-          set -xeo pipefail
-          sudo apt-get update
-          sudo apt-get install -y --no-install-recommends libdrm2 libxcb1 libasound2t64 libxv1 libc++1 libvdpau1 libva2 nasm libx264-dev
+      - name: Setup FFmpeg
+        uses: ./.github/actions/setup-ffmpeg
 
-      - uses: dtolnay/rust-toolchain@stable
-        id: setup-rust
+      - name: Setup Rust
+        uses: ./.github/actions/setup-rust
         with:
           toolchain: ${{ env.RUST_TOOLCHAIN }}
+          tools: cargo-nextest,cargo-llvm-cov
           components: llvm-tools-preview
-
-      - name: Install ffmpeg
-        run: |
-          set -xeo pipefail
-
-          curl -L https://sourceforge.net/projects/avbuild/files/linux/ffmpeg-7.1-linux-clang-default.tar.xz/download -o ffmpeg.tar.xz
-          tar -xvf ffmpeg.tar.xz
-
-          sudo mv ffmpeg-7.1-linux-clang-default/include/* /usr/include
-          sudo mv ffmpeg-7.1-linux-clang-default/lib/amd64/* /usr/local/lib
-          sudo mv ffmpeg-7.1-linux-clang-default/bin/amd64/* /usr/local/bin
-          sudo rm -rf ffmpeg-7.1-linux-clang-default
-          sudo rm -rf ffmpeg.tar.xz
-          sudo ldconfig
-
-      - uses: Swatinem/rust-cache@v2
-        with:
-          prefix-key: "v0-rust-${{ steps.setup-rust.outputs.cachekey }}"
           shared-key: test
-
-      - uses: taiki-e/install-action@v2
-        with:
-          tool: cargo-nextest,cargo-llvm-cov
 
       # Note; we don't run the powerset here because it's very slow on CI
       # Perhaps we should consider it at some point.
@@ -159,21 +122,22 @@ jobs:
           cargo +${{ env.RUST_TOOLCHAIN }} llvm-cov test --all-features --doc --no-report
           cargo +${{ env.RUST_TOOLCHAIN }} llvm-cov report --lcov --output-path ./lcov.info
 
-      - name: Codecov Override
+      - name: Brawl Override
         if: ${{ startsWith(github.ref, 'refs/heads/automation/brawl/try/') }}
+        id: brawl-override
         run: |
           PR_NUMBER=$(echo ${{ github.ref }} | sed -n 's/^refs\/heads\/automation\/brawl\/try\/\([0-9]*\)$/\1/p')
-          echo "PR_NUMBER=$PR_NUMBER" >> $GITHUB_ENV
+          echo "pr_number=$PR_NUMBER" >> $GITHUB_OUTPUT
           RUN_COMMIT_SHA=$(git log -1 --pretty=format:%H)
-          echo "RUN_COMMIT_SHA=$RUN_COMMIT_SHA" >> $GITHUB_ENV
+          echo "run_commit_sha=$RUN_COMMIT_SHA" >> $GITHUB_OUTPUT
 
       - uses: codecov/codecov-action@v5
         with:
           fail_ci_if_error: true
           files: ./lcov.info
           token: ${{ secrets.CODECOV_TOKEN }}
-          override_pr: ${{ env.PR_NUMBER || github.event.pull_request.number || '' }}
-          override_commit: ${{ env.RUN_COMMIT_SHA || env.SHA }}
+          override_pr: ${{ steps.brawl-override.outputs.pr_number || github.event.pull_request.number || '' }}
+          override_commit: ${{ steps.brawl-override.outputs.run_commit_sha || env.SHA }}
           verbose: true
 
       - name: Upload test results to Codecov
@@ -181,8 +145,8 @@ jobs:
         uses: codecov/test-results-action@v1
         with:
           files: ./target/nextest/ci/junit.xml
-          override_pr: ${{ env.PR_NUMBER || github.event.pull_request.number || '' }}
-          override_commit: ${{ env.RUN_COMMIT_SHA || env.SHA }}
+          override_pr: ${{ steps.brawl-override.outputs.pr_number || github.event.pull_request.number || '' }}
+          override_commit: ${{ steps.brawl-override.outputs.run_commit_sha || env.SHA }}
           token: ${{ secrets.CODECOV_TOKEN }}
 
   grind:
@@ -194,44 +158,23 @@ jobs:
         with:
           ref: ${{ env.SHA }}
 
-      - name: Setup system deps
-        run: |
-          set -xeo pipefail
-          sudo apt-get update
-          sudo apt-get install -y --no-install-recommends libdrm2 libxcb1 libasound2t64 libxv1 libc++1 libvdpau1 libva2 nasm libx264-dev valgrind
+      - name: Setup FFmpeg
+        uses: ./.github/actions/setup-ffmpeg
 
-      - uses: dtolnay/rust-toolchain@stable
-        id: setup-rust
+      - name: Setup Rust
+        uses: ./.github/actions/setup-rust
         with:
           toolchain: ${{ env.RUST_TOOLCHAIN }}
+          tools: cargo-nextest,cargo-llvm-cov
           components: llvm-tools-preview
-
-      - name: Install ffmpeg
-        run: |
-          set -xeo pipefail
-
-          curl -L https://sourceforge.net/projects/avbuild/files/linux/ffmpeg-7.1-linux-clang-default.tar.xz/download -o ffmpeg.tar.xz
-          tar -xvf ffmpeg.tar.xz
-
-          sudo mv ffmpeg-7.1-linux-clang-default/include/* /usr/include
-          sudo mv ffmpeg-7.1-linux-clang-default/lib/amd64/* /usr/local/lib
-          sudo mv ffmpeg-7.1-linux-clang-default/bin/amd64/* /usr/local/bin
-          sudo rm -rf ffmpeg-7.1-linux-clang-default
-          sudo rm -rf ffmpeg.tar.xz
-          sudo ldconfig
-
-      - uses: Swatinem/rust-cache@v2
-        with:
-          prefix-key: "v0-rust-${{ steps.setup-rust.outputs.cachekey }}"
           shared-key: grind
-
-      - uses: taiki-e/install-action@v2
-        with:
-          tool: cargo-nextest,cargo-llvm-cov
 
       - name: Run valgrind
         run: |
-          RUSTFLAGS="--cfg=valgrind" CARGO_TARGET_X86_64_UNKNOWN_LINUX_GNU_RUNNER="valgrind --error-exitcode=1 --leak-check=full --gen-suppressions=all --suppressions=$(pwd)/valgrind_suppressions.log" cargo +${{ env.RUST_TOOLCHAIN }} nextest run --all-features --no-fail-fast --profile ci
+          set -xeo pipefail
+          export RUSTFLAGS="--cfg=valgrind"
+          export CARGO_TARGET_X86_64_UNKNOWN_LINUX_GNU_RUNNER="valgrind --error-exitcode=1 --leak-check=full --gen-suppressions=all --suppressions=$(pwd)/valgrind_suppressions.log"
+          cargo +${{ env.RUST_TOOLCHAIN }} nextest run --all-features --no-fail-fast --profile ci
 
   docs:
     name: Docs
@@ -243,43 +186,36 @@ jobs:
         with:
           ref: ${{ env.SHA }}
 
-      - name: Setup system deps
-        run: |
-          sudo apt-get install -y --no-install-recommends nasm libx264-dev
+      - name: Setup FFmpeg
+        uses: ./.github/actions/setup-ffmpeg
 
-      - uses: dtolnay/rust-toolchain@stable
-        id: setup-rust
+      - name: Setup Rust
+        uses: ./.github/actions/setup-rust
         with:
           toolchain: ${{ env.RUST_TOOLCHAIN }}
           components: rust-docs
-
-      - uses: Swatinem/rust-cache@v2
-        with:
-          prefix-key: "v0-rust-${{ steps.setup-rust.outputs.cachekey }}"
           shared-key: docs
 
       - name: Build docs
         run: |
-          RUSTDOCFLAGS="-D warnings --cfg docsrs --enable-index-page -Zunstable-options" cargo +${{ env.RUST_TOOLCHAIN }} doc --no-deps --all-features
+          set -xeo pipefail
+          export RUSTDOCFLAGS="-D warnings --cfg docsrs --enable-index-page -Zunstable-options"
+          cargo +${{ env.RUST_TOOLCHAIN }} doc --no-deps --all-features
 
-      - name: Get PR Number
+      - name: Brawl Override
         if: ${{ startsWith(github.ref, 'refs/heads/automation/brawl/try/') }}
+        id: brawl-override
         run: |
           PR_NUMBER=$(echo ${{ github.ref }} | sed -n 's/^refs\/heads\/automation\/brawl\/try\/\([0-9]*\)$/\1/p')
-          echo "PR_NUMBER=$PR_NUMBER" >> $GITHUB_ENV
-
-      - name: Get short commit SHA
-        run: |
-          SHORT_SHA=$(echo ${{ env.SHA }} | cut -c 1-7)
-          echo "SHORT_SHA=$SHORT_SHA" >> $GITHUB_ENV
+          echo "pr_number=$PR_NUMBER" >> $GITHUB_OUTPUT
 
       - name: Insert custom html for PR
         if: ${{ startsWith(github.ref, 'refs/heads/automation/brawl/try/') || github.event.pull_request.head.repo.full_name == github.repository }}
-        run: .github/patch-docs.sh ${{ github.event.repository.html_url }} ${{ env.SHA }} ${{ env.SHORT_SHA }} ${{ env.PR_NUMBER || github.event.pull_request.number }}
+        run: .github/patch-docs.sh ${{ github.event.repository.html_url }} ${{ env.SHA }} ${{ steps.brawl-override.outputs.pr_number || github.event.pull_request.number }}
 
       - name: Insert custom html for merge
         if: ${{ startsWith(github.ref, 'refs/heads/automation/brawl/merge/') }}
-        run: .github/patch-docs.sh ${{ github.event.repository.html_url }} ${{ env.SHA }} ${{ env.SHORT_SHA }}
+        run: .github/patch-docs.sh ${{ github.event.repository.html_url }} ${{ env.SHA }}
 
       - name: Upload docs
         uses: actions/upload-artifact@v4
@@ -294,7 +230,7 @@ jobs:
         with:
           apiToken: ${{ secrets.CF_DOCS_API_KEY }}
           accountId: ${{ secrets.CF_DOCS_ACCOUNT_ID }}
-          command: pages deploy --project-name=scuffle-docrs --branch=pr/${{ env.PR_NUMBER || github.event.pull_request.number }} --commit-hash=${{ env.SHA }} --commit-dirty=true ./target/doc
+          command: pages deploy --project-name=scuffle-docrs --branch=pr/${{ steps.brawl-override.outputs.pr_number || github.event.pull_request.number }} --commit-hash=${{ env.SHA }} --commit-dirty=true ./target/doc
 
   package:
     name: Package
@@ -305,46 +241,21 @@ jobs:
         with:
           ref: ${{ env.SHA }}
 
-      - name: Setup system deps
-        run: |
-          set -xeo pipefail
-          sudo apt-get update
-          sudo apt-get install -y --no-install-recommends libdrm2 libxcb1 libasound2t64 libxv1 libc++1 libvdpau1 libva2 nasm libx264-dev valgrind
+      - name: Setup FFmpeg
+        uses: ./.github/actions/setup-ffmpeg
 
-      - uses: dtolnay/rust-toolchain@stable
-        id: setup-rust
+      - name: Setup Rust
+        uses: ./.github/actions/setup-rust
         with:
           toolchain: stable
-
-      - name: Install ffmpeg
-        run: |
-          set -xeo pipefail
-
-          curl -L https://sourceforge.net/projects/avbuild/files/linux/ffmpeg-7.1-linux-clang-default.tar.xz/download -o ffmpeg.tar.xz
-          tar -xvf ffmpeg.tar.xz
-
-          sudo mv ffmpeg-7.1-linux-clang-default/include/* /usr/include
-          sudo mv ffmpeg-7.1-linux-clang-default/lib/amd64/* /usr/local/lib
-          sudo mv ffmpeg-7.1-linux-clang-default/bin/amd64/* /usr/local/bin
-          sudo rm -rf ffmpeg-7.1-linux-clang-default
-          sudo rm -rf ffmpeg.tar.xz
-          sudo ldconfig
-
-      - uses: Swatinem/rust-cache@v2
-        with:
-          prefix-key: "v0-rust-${{ steps.setup-rust.outputs.cachekey }}"
           shared-key: package
-
-      - uses: taiki-e/install-action@v2
-        with:
-          tool: just,cargo-hakari
+          tools: just,cargo-hakari
 
       - name: Disable Hakari
         run: cargo hakari disable
 
       - name: Run Powerset
-        run: |
-          just powerset package -- --allow-dirty
+        run: just powerset package -- --allow-dirty
 
   brawl-done:
     runs-on: ubuntu-24.04

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -45,8 +45,21 @@ jobs:
           prefix-key: "v0-rust-${{ steps.setup-rust.outputs.cachekey }}"
           shared-key: clippy
 
+      - uses: taiki-e/install-action@v2
+        with:
+          tool: just,cargo-hakari
+
+      - name: Disable Hakari
+        if: ${{ github.event_name == 'push' }}
+        run: cargo hakari disable
+
       - name: Make sure code is linted
+        if: ${{ github.event_name == 'pull_request' }}
         run: cargo +${{ env.RUST_TOOLCHAIN }} clippy --all-features --all-targets
+
+      - name: Make sure code is linted
+        if: ${{ github.event_name == 'push' }}
+        run: just powerset clippy
 
   fmt:
     name: Fmt
@@ -283,8 +296,8 @@ jobs:
           accountId: ${{ secrets.CF_DOCS_ACCOUNT_ID }}
           command: pages deploy --project-name=scuffle-docrs --branch=pr/${{ env.PR_NUMBER || github.event.pull_request.number }} --commit-hash=${{ env.SHA }} --commit-dirty=true ./target/doc
 
-  powerset:
-    name: Powerset
+  package:
+    name: Package
     if: ${{ github.event_name == 'push' }}
     runs-on: ubuntu-24.04
     steps:
@@ -301,8 +314,7 @@ jobs:
       - uses: dtolnay/rust-toolchain@stable
         id: setup-rust
         with:
-          toolchain: ${{ env.RUST_TOOLCHAIN }}
-          components: clippy
+          toolchain: stable
 
       - name: Install ffmpeg
         run: |
@@ -321,7 +333,7 @@ jobs:
       - uses: Swatinem/rust-cache@v2
         with:
           prefix-key: "v0-rust-${{ steps.setup-rust.outputs.cachekey }}"
-          shared-key: powerset
+          shared-key: package
 
       - uses: taiki-e/install-action@v2
         with:
@@ -332,11 +344,11 @@ jobs:
 
       - name: Run Powerset
         run: |
-          just powerset clippy
+          just powerset package -- --allow-dirty
 
   brawl-done:
     runs-on: ubuntu-24.04
-    needs: [hakari, test, clippy, fmt, grind, docs, powerset]
+    needs: [hakari, test, clippy, fmt, grind, docs, package]
     if: ${{ !cancelled() && github.event_name == 'push' }}
     steps:
       - name: calculate the correct exit status

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -169,6 +169,12 @@ jobs:
           components: llvm-tools-preview
           shared-key: grind
 
+      - name: Install Valgrind
+        run: |
+          set -xeo pipefail
+          sudo apt-get update
+          sudo apt-get install -y --no-install-recommends valgrind
+
       - name: Run valgrind
         run: |
           set -xeo pipefail

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -45,11 +45,17 @@ jobs:
 
       - name: Make sure code is linted
         if: ${{ github.event_name == 'pull_request' }}
-        run: cargo +${{ env.RUST_TOOLCHAIN }} clippy --all-features --all-targets
+        run: |
+          set -xeo pipefail
+          export RUSTFLAGS="-Dwarnings"
+          cargo +${{ env.RUST_TOOLCHAIN }} clippy -Z unstable-options --all-features --all-targets --no-deps
 
       - name: Make sure code is linted
         if: ${{ github.event_name == 'push' }}
-        run: just powerset clippy
+        run: |
+          set -xeo pipefail
+          export RUSTFLAGS="-Dwarnings"
+          just powerset clippy -- --all-targets --no-deps -Z unstable-options
 
   fmt:
     name: Fmt

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -236,6 +236,8 @@ jobs:
     name: Package
     if: ${{ github.event_name == 'push' }}
     runs-on: ubuntu-24.04
+    env:
+      RUST_TOOLCHAIN: stable
     steps:
       - uses: actions/checkout@v4
         with:
@@ -247,7 +249,7 @@ jobs:
       - name: Setup Rust
         uses: ./.github/actions/setup-rust
         with:
-          toolchain: stable
+          toolchain: ${{ env.RUST_TOOLCHAIN }}
           shared-key: package
           tools: just,cargo-hakari
 

--- a/.github/workflows/crate-release.yaml
+++ b/.github/workflows/crate-release.yaml
@@ -16,11 +16,8 @@ jobs:
       - name: Checkout repository
         uses: actions/checkout@v4
 
-      - name: Setup system deps
-        run: |
-          set -xeo pipefail
-          sudo apt-get update
-          sudo apt-get install -y --no-install-recommends nasm libx264-dev libdrm2 libxcb1 libasound2t64 libxv1 libc++1 libvdpau1 libva2
+      - name: Setup FFmpeg
+        uses: ./.github/actions/setup-ffmpeg
 
       - uses: dtolnay/rust-toolchain@stable
         id: setup-rust

--- a/crates/bootstrap/telemetry/Cargo.toml
+++ b/crates/bootstrap/telemetry/Cargo.toml
@@ -39,6 +39,7 @@ scuffle-workspace-hack.workspace = true
 [dev-dependencies]
 scuffle-metrics.workspace = true
 reqwest = { version = "0.12.12", default-features = false, features = [ "rustls-tls" ] }
+tokio = { version = "1", features = [ "macros" ] }
 
 [features]
 default = ["prometheus", "pprof", "opentelemetry-metrics", "opentelemetry-traces", "opentelemetry-logs"]

--- a/crates/bootstrap/telemetry/src/lib.rs
+++ b/crates/bootstrap/telemetry/src/lib.rs
@@ -426,13 +426,17 @@ async fn opentelemetry_flush<G: TelemetryConfig>(
 
 #[cfg(test)]
 #[cfg_attr(all(test, coverage_nightly), coverage(off))]
+#[cfg(all(feature = "opentelemetry-metrics", feature = "opentelemetry-traces", feature = "opentelemetry-logs"))]
 mod tests {
     use std::net::SocketAddr;
     use std::sync::Arc;
 
     use bytes::Bytes;
+    #[cfg(feature = "opentelemetry-logs")]
     use opentelemetry_sdk::logs::LoggerProvider;
+    #[cfg(feature = "opentelemetry-metrics")]
     use opentelemetry_sdk::metrics::SdkMeterProvider;
+    #[cfg(feature = "opentelemetry-traces")]
     use opentelemetry_sdk::trace::TracerProvider;
     use scuffle_bootstrap::{GlobalWithoutConfig, Service};
 
@@ -479,6 +483,7 @@ mod tests {
     async fn telemetry_http_server() {
         struct TestGlobal {
             bind_addr: SocketAddr,
+            #[cfg(feature = "prometheus")]
             prometheus: prometheus_client::registry::Registry,
             open_telemetry: crate::opentelemetry::OpenTelemetry,
         }
@@ -492,6 +497,7 @@ mod tests {
 
                 let exporter = scuffle_metrics::prometheus::exporter().build();
                 prometheus.register_collector(exporter.collector());
+
                 let metrics = SdkMeterProvider::builder().with_reader(exporter).build();
                 opentelemetry::global::set_meter_provider(metrics.clone());
 

--- a/crates/bootstrap/telemetry/src/lib.rs
+++ b/crates/bootstrap/telemetry/src/lib.rs
@@ -426,7 +426,11 @@ async fn opentelemetry_flush<G: TelemetryConfig>(
 
 #[cfg(test)]
 #[cfg_attr(all(test, coverage_nightly), coverage(off))]
-#[cfg(all(feature = "opentelemetry-metrics", feature = "opentelemetry-traces", feature = "opentelemetry-logs"))]
+#[cfg(all(
+    feature = "opentelemetry-metrics",
+    feature = "opentelemetry-traces",
+    feature = "opentelemetry-logs"
+))]
 mod tests {
     use std::net::SocketAddr;
     use std::sync::Arc;

--- a/crates/settings/Cargo.toml
+++ b/crates/settings/Cargo.toml
@@ -23,6 +23,9 @@ anyhow = { version = "1.0", optional = true }
 scuffle-bootstrap = { workspace = true, optional = true }
 scuffle-workspace-hack.workspace = true
 
+[dev-dependencies]
+serde = { version = "1", features = [ "derive" ] }
+
 [features]
 cli = ["clap"]
 ron = ["config/ron"]

--- a/crates/settings/src/lib.rs
+++ b/crates/settings/src/lib.rs
@@ -348,10 +348,13 @@ macro_rules! bootstrap {
 #[cfg(test)]
 #[cfg_attr(all(test, coverage_nightly), coverage(off))]
 mod tests {
-    use crate::{parse_settings, Cli, Options};
+    use crate::{parse_settings, Options};
+    #[cfg(feature = "cli")]
+    use crate::Cli;
 
     #[derive(Debug, serde::Deserialize)]
     struct TestSettings {
+        #[cfg_attr(not(feature = "cli"), allow(dead_code))]
         key: String,
     }
 
@@ -363,6 +366,7 @@ mod tests {
     }
 
     #[test]
+    #[cfg(feature = "cli")]
     fn parse_cli() {
         let options = Options {
             cli: Some(Cli {
@@ -380,6 +384,7 @@ mod tests {
     }
 
     #[test]
+    #[cfg(feature = "cli")]
     fn cli_error() {
         let options = Options {
             cli: Some(Cli {
@@ -401,6 +406,7 @@ mod tests {
     }
 
     #[test]
+    #[cfg(feature = "cli")]
     fn parse_file() {
         let options = Options {
             cli: Some(Cli {
@@ -418,6 +424,7 @@ mod tests {
     }
 
     #[test]
+    #[cfg(feature = "cli")]
     fn file_error() {
         let options = Options {
             cli: Some(Cli {
@@ -443,6 +450,7 @@ mod tests {
     }
 
     #[test]
+    #[cfg(feature = "cli")]
     fn parse_env() {
         let options = Options {
             cli: Some(Cli {
@@ -462,6 +470,7 @@ mod tests {
     }
 
     #[test]
+    #[cfg(feature = "cli")]
     fn overrides() {
         let options = Options {
             cli: Some(Cli {
@@ -481,6 +490,7 @@ mod tests {
     }
 
     #[test]
+    #[cfg(all(feature = "templates", feature = "cli"))]
     fn templates() {
         let options = Options {
             cli: Some(Cli {

--- a/crates/settings/src/lib.rs
+++ b/crates/settings/src/lib.rs
@@ -348,9 +348,9 @@ macro_rules! bootstrap {
 #[cfg(test)]
 #[cfg_attr(all(test, coverage_nightly), coverage(off))]
 mod tests {
-    use crate::{parse_settings, Options};
     #[cfg(feature = "cli")]
     use crate::Cli;
+    use crate::{parse_settings, Options};
 
     #[derive(Debug, serde::Deserialize)]
     struct TestSettings {


### PR DESCRIPTION
Moves the clippy powerset stuff into the clippy job (only runs on a brawl run) and then adds a new job that runs `cargo package`. Cargo Package is a tool ran before `cargo publish` (it runs automatically unless you do `--no-verify`). This is a sanity check to test if the crate compiles before uploading it to crates.io. The reason we do this in a power-set is because we want to make sure that all features of the crate compile successfully. This is a known issue on crates.io where sometimes crates break and or dont work depending on the features they are enabled with.

CLOUD-63

This PR also splits our ci into components, to reuse existing setup code related to `setup-rust` where we install the rust tool chain, use a cache and install custom rust tools. As well as `setup-ffmpeg` where we install and configure ffmpeg.

CLOUD-64
