### PR TITLE
add semver checks

### DIFF
--- a/.github/actions/ci/semver-checks/action.yaml
+++ b/.github/actions/ci/semver-checks/action.yaml
@@ -2,12 +2,9 @@ name: Semver-checks
 runs:
   using: "composite"
   steps:
-    - name: Cargo Hackari disable
-      run: cargo hakari disable
-
     - name: Run xtask semver checks (against main branch)
       shell: bash
       env:
         RUSTFLAGS: "--cfg reqwest_unstable"
       run:
-        cargo xtask semver-checks
+        cargo xtask semver-checks --disable-hakari true

--- a/.github/actions/ci/semver-checks/action.yaml
+++ b/.github/actions/ci/semver-checks/action.yaml
@@ -2,10 +2,8 @@ name: Semver-checks
 runs:
   using: "composite"
   steps:
-    # - name: Checkout repository (with full history)
-    #   uses: actions/checkout@v4
-    #   with:
-    #     fetch-depth: 0
+    - name: Cargo Hackari disable
+      run: cargo hakari disable
 
     - name: Run xtask semver checks (against main branch)
       shell: bash

--- a/.github/actions/ci/semver-checks/action.yaml
+++ b/.github/actions/ci/semver-checks/action.yaml
@@ -7,4 +7,4 @@ runs:
       env:
         RUSTFLAGS: "--cfg reqwest_unstable"
       run:
-        cargo xtask semver-checks --disable-hakari true
+        cargo xtask semver-checks --disable-hakari

--- a/.github/actions/ci/semver-checks/action.yaml
+++ b/.github/actions/ci/semver-checks/action.yaml
@@ -1,0 +1,15 @@
+name: Semver-checks
+runs:
+  using: "composite"
+  steps:
+    # - name: Checkout repository (with full history)
+    #   uses: actions/checkout@v4
+    #   with:
+    #     fetch-depth: 0
+
+    - name: Run xtask semver checks (against main branch)
+      shell: bash
+      env:
+        RUSTFLAGS: "--cfg reqwest_unstable"
+      run:
+        cargo xtask semver-checks

--- a/.github/actions/ci/semver-checks/action.yaml
+++ b/.github/actions/ci/semver-checks/action.yaml
@@ -3,8 +3,17 @@ runs:
   using: "composite"
   steps:
     - name: Run xtask semver checks (against main branch)
+      id: semver_checks
       shell: bash
       env:
         RUSTFLAGS: "--cfg reqwest_unstable"
-      run:
-        cargo xtask semver-checks --disable-hakari
+      run: |
+        result=$(cargo xtask semver-checks --disable-hakari)
+        echo "checks_output=$result" >> $GITHUB_OUTPUT
+
+    - name: Add/update PR comment
+      uses: thollander/actions-comment-pull-request@v1
+      with:
+        message: ${{ steps.semver_checks.outputs.checks_output }}
+      env:
+        GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/actions/ci/semver-checks/action.yaml
+++ b/.github/actions/ci/semver-checks/action.yaml
@@ -9,7 +9,9 @@ runs:
         RUSTFLAGS: "--cfg reqwest_unstable"
       run: |
         result=$(cargo xtask semver-checks --disable-hakari)
-        echo "checks_output=$result" >> $GITHUB_OUTPUT
+        echo "checks_output<<EOF" >> $GITHUB_OUTPUT
+        echo "$result" >> $GITHUB_OUTPUT
+        echo "EOF" >> $GITHUB_OUTPUT
 
     - name: Add/update PR comment
       uses: thollander/actions-comment-pull-request@v1

--- a/.github/actions/ci/semver-checks/action.yaml
+++ b/.github/actions/ci/semver-checks/action.yaml
@@ -18,3 +18,5 @@ runs:
       with:
         # github-token: ${{ secrets.GITHUB_TOKEN }}
         message: ${{ steps.semver_checks.outputs.checks_output }}
+      permissions:
+        pull-requests: write

--- a/.github/actions/ci/semver-checks/action.yaml
+++ b/.github/actions/ci/semver-checks/action.yaml
@@ -14,6 +14,5 @@ runs:
     - name: Add/update PR comment
       uses: thollander/actions-comment-pull-request@v1
       with:
+        # github-token: ${{ secrets.GITHUB_TOKEN }}
         message: ${{ steps.semver_checks.outputs.checks_output }}
-      env:
-        GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/actions/ci/semver-checks/action.yaml
+++ b/.github/actions/ci/semver-checks/action.yaml
@@ -17,5 +17,3 @@ runs:
       uses: thollander/actions-comment-pull-request@v1
       with:
         message: ${{ steps.semver_checks.outputs.checks_output }}
-        permissions:
-          pull-requests: write

--- a/.github/actions/ci/semver-checks/action.yaml
+++ b/.github/actions/ci/semver-checks/action.yaml
@@ -16,7 +16,6 @@ runs:
     - name: Add/update PR comment
       uses: thollander/actions-comment-pull-request@v1
       with:
-        # github-token: ${{ secrets.GITHUB_TOKEN }}
         message: ${{ steps.semver_checks.outputs.checks_output }}
-      permissions:
-        pull-requests: write
+        permissions:
+          pull-requests: write

--- a/.github/scripts/ci-matrix-prep.py
+++ b/.github/scripts/ci-matrix-prep.py
@@ -567,7 +567,7 @@ def create_semver_checks_jobs() -> list[Job]:
 
     jobs.append(
         Job(
-            runner=GITHUB_DEFAULT_RUNNER,
+            runner=LINUX_X86_64,
             job_name="Semver-checks",
             job="semver-checks",
             ffmpeg=FfmpegSetup(),

--- a/.github/scripts/ci-matrix-prep.py
+++ b/.github/scripts/ci-matrix-prep.py
@@ -575,7 +575,7 @@ def create_semver_checks_jobs() -> list[Job]:
             rust=RustSetup(
                 toolchain="stable",
                 components="rust-docs",
-                tools="cargo-semver-checks",
+                tools="cargo-semver-checks,cargo-hakari",
                 shared_key="cargo-semver-checks",
                 cache_backend="ubicloud",
             ),

--- a/.github/scripts/ci-matrix-prep.py
+++ b/.github/scripts/ci-matrix-prep.py
@@ -102,13 +102,24 @@ class HakariMatrix:
 
 
 @dataclass
+class SemverChecksMatrix:
+    pass
+
+
+@dataclass
 class Job:
     runner: str
     job_name: str
     rust: Optional[RustSetup]
     ffmpeg: Optional[FfmpegSetup]
     inputs: (
-        GrindMatrix | DocsMatrix | ClippyMatrix | TestMatrix | FmtMatrix | HakariMatrix
+        GrindMatrix
+        | DocsMatrix
+        | ClippyMatrix
+        | TestMatrix
+        | FmtMatrix
+        | HakariMatrix
+        | SemverChecksMatrix
     )
     job: str
     secrets: Optional[list[str]] = None
@@ -147,7 +158,7 @@ def create_docs_jobs() -> list[Job]:
         jobs.append(
             Job(
                 runner=LINUX_ARM64,
-                job_name=f"Docs (Linux arm64)",
+                job_name="Docs (Linux arm64)",
                 job="docs",
                 ffmpeg=FfmpegSetup(),
                 inputs=DocsMatrix(
@@ -168,7 +179,7 @@ def create_docs_jobs() -> list[Job]:
         jobs.append(
             Job(
                 runner=WINDOWS_X86_64,
-                job_name=f"Docs (Windows x86_64)",
+                job_name="Docs (Windows x86_64)",
                 job="docs",
                 ffmpeg=FfmpegSetup(),
                 inputs=DocsMatrix(
@@ -189,7 +200,7 @@ def create_docs_jobs() -> list[Job]:
         jobs.append(
             Job(
                 runner=MACOS_X86_64,
-                job_name=f"Docs (macOS x86_64)",
+                job_name="Docs (macOS x86_64)",
                 job="docs",
                 ffmpeg=FfmpegSetup(),
                 inputs=DocsMatrix(
@@ -210,7 +221,7 @@ def create_docs_jobs() -> list[Job]:
         jobs.append(
             Job(
                 runner=MACOS_ARM64,
-                job_name=f"Docs (macOS arm64)",
+                job_name="Docs (macOS arm64)",
                 job="docs",
                 ffmpeg=FfmpegSetup(),
                 inputs=DocsMatrix(
@@ -237,7 +248,7 @@ def create_clippy_jobs() -> list[Job]:
     jobs.append(
         Job(
             runner=LINUX_X86_64,
-            job_name=f"Clippy (Linux x86_64)",
+            job_name="Clippy (Linux x86_64)",
             job="clippy",
             ffmpeg=FfmpegSetup(),
             inputs=ClippyMatrix(
@@ -257,7 +268,7 @@ def create_clippy_jobs() -> list[Job]:
         jobs.append(
             Job(
                 runner=LINUX_ARM64,
-                job_name=f"Clippy (Linux arm64)",
+                job_name="Clippy (Linux arm64)",
                 job="clippy",
                 ffmpeg=FfmpegSetup(),
                 inputs=ClippyMatrix(
@@ -276,7 +287,7 @@ def create_clippy_jobs() -> list[Job]:
         jobs.append(
             Job(
                 runner=WINDOWS_X86_64,
-                job_name=f"Clippy (Windows x86_64)",
+                job_name="Clippy (Windows x86_64)",
                 job="clippy",
                 ffmpeg=FfmpegSetup(),
                 inputs=ClippyMatrix(
@@ -295,7 +306,7 @@ def create_clippy_jobs() -> list[Job]:
         jobs.append(
             Job(
                 runner=MACOS_X86_64,
-                job_name=f"Clippy (macOS x86_64)",
+                job_name="Clippy (macOS x86_64)",
                 job="clippy",
                 ffmpeg=FfmpegSetup(),
                 inputs=ClippyMatrix(
@@ -314,7 +325,7 @@ def create_clippy_jobs() -> list[Job]:
         jobs.append(
             Job(
                 runner=MACOS_ARM64,
-                job_name=f"Clippy (macOS arm64)",
+                job_name="Clippy (macOS arm64)",
                 job="clippy",
                 ffmpeg=FfmpegSetup(),
                 inputs=ClippyMatrix(
@@ -349,7 +360,7 @@ def create_test_jobs() -> list[Job]:
     jobs.append(
         Job(
             runner=LINUX_X86_64,
-            job_name=f"Test (Linux x86_64)",
+            job_name="Test (Linux x86_64)",
             job="test",
             ffmpeg=FfmpegSetup(),
             inputs=TestMatrix(
@@ -371,7 +382,7 @@ def create_test_jobs() -> list[Job]:
         jobs.append(
             Job(
                 runner=LINUX_ARM64,
-                job_name=f"Test (Linux arm64)",
+                job_name="Test (Linux arm64)",
                 job="test",
                 ffmpeg=FfmpegSetup(),
                 inputs=TestMatrix(
@@ -392,7 +403,7 @@ def create_test_jobs() -> list[Job]:
         jobs.append(
             Job(
                 runner=WINDOWS_X86_64,
-                job_name=f"Test (Windows x86_64)",
+                job_name="Test (Windows x86_64)",
                 job="test",
                 ffmpeg=FfmpegSetup(),
                 inputs=TestMatrix(
@@ -413,7 +424,7 @@ def create_test_jobs() -> list[Job]:
         jobs.append(
             Job(
                 runner=MACOS_X86_64,
-                job_name=f"Test (macOS x86_64)",
+                job_name="Test (macOS x86_64)",
                 job="test",
                 ffmpeg=FfmpegSetup(),
                 inputs=TestMatrix(
@@ -434,7 +445,7 @@ def create_test_jobs() -> list[Job]:
         jobs.append(
             Job(
                 runner=MACOS_ARM64,
-                job_name=f"Test (macOS arm64)",
+                job_name="Test (macOS arm64)",
                 job="test",
                 ffmpeg=FfmpegSetup(),
                 inputs=TestMatrix(
@@ -462,7 +473,7 @@ def create_grind_jobs() -> list[Job]:
         jobs.append(
             Job(
                 runner=LINUX_X86_64,
-                job_name=f"Grind (Linux x86_64)",
+                job_name="Grind (Linux x86_64)",
                 job="grind",
                 ffmpeg=FfmpegSetup(),
                 inputs=GrindMatrix(
@@ -484,7 +495,7 @@ def create_grind_jobs() -> list[Job]:
         jobs.append(
             Job(
                 runner=LINUX_ARM64,
-                job_name=f"Grind (Linux arm64)",
+                job_name="Grind (Linux arm64)",
                 job="grind",
                 ffmpeg=FfmpegSetup(),
                 inputs=GrindMatrix(
@@ -512,7 +523,7 @@ def create_fmt_jobs() -> list[Job]:
     jobs.append(
         Job(
             runner=GITHUB_DEFAULT_RUNNER,
-            job_name=f"Fmt",
+            job_name="Fmt",
             job="fmt",
             ffmpeg=None,
             inputs=FmtMatrix(),
@@ -534,7 +545,7 @@ def create_hakari_jobs() -> list[Job]:
     jobs.append(
         Job(
             runner=GITHUB_DEFAULT_RUNNER,
-            job_name=f"Hakari",
+            job_name="Hakari",
             job="hakari",
             ffmpeg=None,
             inputs=HakariMatrix(),
@@ -551,6 +562,29 @@ def create_hakari_jobs() -> list[Job]:
     return jobs
 
 
+def create_semver_checks_jobs() -> list[Job]:
+    jobs: list[Job] = []
+
+    jobs.append(
+        Job(
+            runner=GITHUB_DEFAULT_RUNNER,
+            job_name="Semver-checks",
+            job="semver-checks",
+            ffmpeg=FfmpegSetup(),
+            inputs=SemverChecksMatrix(),
+            rust=RustSetup(
+                toolchain="stable",
+                components="rust-docs",
+                tools="cargo-semver-checks",
+                shared_key="cargo-semver-checks",
+                cache_backend="ubicloud",
+            ),
+        )
+    )
+
+    return jobs
+
+
 def create_jobs() -> list[Job]:
     jobs = (
         create_docs_jobs()
@@ -559,6 +593,7 @@ def create_jobs() -> list[Job]:
         + create_grind_jobs()
         + create_fmt_jobs()
         + create_hakari_jobs()
+        + create_semver_checks_jobs()
     )
 
     return jobs

--- a/.github/scripts/ci-matrix-prep.py
+++ b/.github/scripts/ci-matrix-prep.py
@@ -103,7 +103,7 @@ class HakariMatrix:
 
 @dataclass
 class SemverChecksMatrix:
-    permissions: str = "pull-requests: write"
+    pass
 
 
 @dataclass
@@ -123,6 +123,7 @@ class Job:
     )
     job: str
     secrets: Optional[list[str]] = None
+    permissions: Optional[str] = None
 
 
 def create_docs_jobs() -> list[Job]:
@@ -579,6 +580,7 @@ def create_semver_checks_jobs() -> list[Job]:
                 shared_key="cargo-semver-checks",
                 cache_backend="ubicloud",
             ),
+            permissions="pull-requests: write"
         )
     )
 

--- a/.github/scripts/ci-matrix-prep.py
+++ b/.github/scripts/ci-matrix-prep.py
@@ -564,6 +564,7 @@ def create_hakari_jobs() -> list[Job]:
 
 def create_semver_checks_jobs() -> list[Job]:
     jobs: list[Job] = []
+    secrets = ["CODECOV_TOKEN"] if not is_fork_pr() else None
 
     jobs.append(
         Job(
@@ -579,6 +580,7 @@ def create_semver_checks_jobs() -> list[Job]:
                 shared_key="cargo-semver-checks",
                 cache_backend="ubicloud",
             ),
+            secrets=secrets
         )
     )
 

--- a/.github/scripts/ci-matrix-prep.py
+++ b/.github/scripts/ci-matrix-prep.py
@@ -103,7 +103,7 @@ class HakariMatrix:
 
 @dataclass
 class SemverChecksMatrix:
-    pass
+    permissions: str = "pull-requests: write"
 
 
 @dataclass
@@ -564,7 +564,6 @@ def create_hakari_jobs() -> list[Job]:
 
 def create_semver_checks_jobs() -> list[Job]:
     jobs: list[Job] = []
-    secrets = ["CODECOV_TOKEN"] if not is_fork_pr() else None
 
     jobs.append(
         Job(
@@ -580,7 +579,6 @@ def create_semver_checks_jobs() -> list[Job]:
                 shared_key="cargo-semver-checks",
                 cache_backend="ubicloud",
             ),
-            secrets=secrets
         )
     )
 

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4359,6 +4359,7 @@ dependencies = [
  "anyhow",
  "cargo_metadata",
  "clap",
+ "regex",
  "serde",
  "serde_json",
  "toml_edit",

--- a/crates/aac/Cargo.toml
+++ b/crates/aac/Cargo.toml
@@ -20,3 +20,18 @@ num-traits = "0.2"
 num-derive = "0.4"
 scuffle-workspace-hack.workspace = true
 scuffle-bytes-util.workspace = true
+
+[package.metadata.cargo_check_external_types]
+allowed_external_types = [
+  # major released
+  "bytes::*",
+
+  # not major released
+  "byteorder::*",
+  "num_traits::*",
+  "num_derive::*",
+
+  # workspace-specific (safe to expose within the same ecosystem)
+  "scuffle_workspace_hack::*",
+  "scuffle_bytes_util::*",
+]

--- a/crates/aac/Cargo.toml
+++ b/crates/aac/Cargo.toml
@@ -30,8 +30,4 @@ allowed_external_types = [
   "byteorder::*",
   "num_traits::*",
   "num_derive::*",
-
-  # workspace-specific (safe to expose within the same ecosystem)
-  "scuffle_workspace_hack::*",
-  "scuffle_bytes_util::*",
 ]

--- a/crates/amf0/Cargo.toml
+++ b/crates/amf0/Cargo.toml
@@ -30,3 +30,19 @@ serde = ["dep:serde", "scuffle-bytes-util/serde"]
 [package.metadata.docs.rs]
 all-features = true
 rustdoc-args = ["--cfg", "docsrs"]
+
+[package.metadata.cargo_check_external_types]
+allowed_external_types = [
+  # major released
+  "bytes::*",
+
+  # not major released
+  "byteorder::*",
+  "num_traits::*",
+  "num_derive::*",
+  "thiserror::*",
+
+  # workspace-specific (safe to expose within the same ecosystem)
+  "scuffle_bytes_util::*",
+  "scuffle_workspace_hack::*",
+]

--- a/crates/amf0/Cargo.toml
+++ b/crates/amf0/Cargo.toml
@@ -41,8 +41,4 @@ allowed_external_types = [
   "num_traits::*",
   "num_derive::*",
   "thiserror::*",
-
-  # workspace-specific (safe to expose within the same ecosystem)
-  "scuffle_bytes_util::*",
-  "scuffle_workspace_hack::*",
 ]

--- a/crates/av1/Cargo.toml
+++ b/crates/av1/Cargo.toml
@@ -21,3 +21,16 @@ scuffle-workspace-hack.workspace = true
 
 [dev-dependencies]
 insta = "1.42"
+
+[package.metadata.cargo_check_external_types]
+allowed_external_types = [
+  # major released
+  "bytes::*",
+
+  # not major released
+  "byteorder::*",
+
+  # workspace-specific (safe to expose within the same ecosystem)
+  "scuffle_bytes_util::*",
+  "scuffle_workspace_hack::*",
+]

--- a/crates/av1/Cargo.toml
+++ b/crates/av1/Cargo.toml
@@ -29,8 +29,4 @@ allowed_external_types = [
 
   # not major released
   "byteorder::*",
-
-  # workspace-specific (safe to expose within the same ecosystem)
-  "scuffle_bytes_util::*",
-  "scuffle_workspace_hack::*",
 ]

--- a/crates/batching/Cargo.toml
+++ b/crates/batching/Cargo.toml
@@ -32,3 +32,13 @@ scuffle-workspace-hack.workspace = true
 criterion = { version = "0.5.1", features = ["async_tokio"] }
 futures = "0.3"
 tokio-test = "0.4.4"
+
+[package.metadata.cargo_check_external_types]
+allowed_external_types = [
+  # major released
+  "tokio::*",
+  "tokio_util::*",
+
+  # workspace-specific (safe to expose within the same ecosystem)
+  "scuffle_workspace_hack::*",
+]

--- a/crates/batching/Cargo.toml
+++ b/crates/batching/Cargo.toml
@@ -38,7 +38,4 @@ allowed_external_types = [
   # major released
   "tokio::*",
   "tokio_util::*",
-
-  # workspace-specific (safe to expose within the same ecosystem)
-  "scuffle_workspace_hack::*",
 ]

--- a/crates/bootstrap/Cargo.toml
+++ b/crates/bootstrap/Cargo.toml
@@ -40,10 +40,25 @@ insta = "1.42"
 postcompile = { workspace = true, features = ["prettyplease"] }
 scuffle-future-ext.workspace = true
 scuffle-signal = { workspace = true, features = ["bootstrap"] }
-
 # For examples:
 serde = { version = "1", features = ["derive"] }
 smart-default = "0.7"
 tracing = "0.1"
 tracing-subscriber = "0.3"
 scuffle-settings = { workspace = true, features = ["bootstrap"] }
+
+[package.metadata.cargo_check_external_types]
+allowed_external_types = [
+  # major released
+  "anyhow::*",
+  "tokio::*",
+  "futures::*",
+  "pin_project_lite::*",
+
+  # workspace-specific (safe to expose within the same ecosystem)
+  "scuffle_context::*",
+  "scuffle_bootstrap_derive::*",
+  "scuffle_workspace_hack::*",
+  "scuffle_future_ext::*",
+  "scuffle_signal::*",
+]

--- a/crates/bootstrap/Cargo.toml
+++ b/crates/bootstrap/Cargo.toml
@@ -54,11 +54,4 @@ allowed_external_types = [
   "tokio::*",
   "futures::*",
   "pin_project_lite::*",
-
-  # workspace-specific (safe to expose within the same ecosystem)
-  "scuffle_context::*",
-  "scuffle_bootstrap_derive::*",
-  "scuffle_workspace_hack::*",
-  "scuffle_future_ext::*",
-  "scuffle_signal::*",
 ]

--- a/crates/bytes-util/Cargo.toml
+++ b/crates/bytes-util/Cargo.toml
@@ -31,7 +31,4 @@ rustdoc-args = ["--cfg", "docsrs"]
 allowed_external_types = [
   # major released
   "bytes::*",
-
-  # workspace-specific (safe to expose within the same ecosystem)
-  "scuffle_workspace_hack::*",
 ]

--- a/crates/bytes-util/Cargo.toml
+++ b/crates/bytes-util/Cargo.toml
@@ -26,3 +26,12 @@ serde = ["dep:serde"]
 [package.metadata.docs.rs]
 all-features = true
 rustdoc-args = ["--cfg", "docsrs"]
+
+[package.metadata.cargo_check_external_types]
+allowed_external_types = [
+  # major released
+  "bytes::*",
+
+  # workspace-specific (safe to expose within the same ecosystem)
+  "scuffle_workspace_hack::*",
+]

--- a/crates/context/Cargo.toml
+++ b/crates/context/Cargo.toml
@@ -31,8 +31,4 @@ allowed_external_types = [
   "pin_project_lite::*",
   "tokio_util::*",
   "tokio::*",
-
-  # workspace-specific (safe to expose within the same ecosystem)
-  "scuffle_workspace_hack::*",
-  "scuffle_future_ext::*",
 ]

--- a/crates/context/Cargo.toml
+++ b/crates/context/Cargo.toml
@@ -23,3 +23,16 @@ scuffle-workspace-hack.workspace = true
 [dev-dependencies]
 tokio-test = "0.4.4"
 scuffle-future-ext.workspace = true
+
+[package.metadata.cargo_check_external_types]
+allowed_external_types = [
+  # major released
+  "futures_lite::*",
+  "pin_project_lite::*",
+  "tokio_util::*",
+  "tokio::*",
+
+  # workspace-specific (safe to expose within the same ecosystem)
+  "scuffle_workspace_hack::*",
+  "scuffle_future_ext::*",
+]

--- a/crates/expgolomb/Cargo.toml
+++ b/crates/expgolomb/Cargo.toml
@@ -24,8 +24,4 @@ bytes = "1.5"
 allowed_external_types = [
   # major released
   "bytes::*",
-
-  # workspace-specific (safe to expose within the same ecosystem)
-  "scuffle_bytes_util::*",
-  "scuffle_workspace_hack::*",
 ]

--- a/crates/expgolomb/Cargo.toml
+++ b/crates/expgolomb/Cargo.toml
@@ -19,3 +19,13 @@ scuffle-workspace-hack.workspace = true
 
 [dev-dependencies]
 bytes = "1.5"
+
+[package.metadata.cargo_check_external_types]
+allowed_external_types = [
+  # major released
+  "bytes::*",
+
+  # workspace-specific (safe to expose within the same ecosystem)
+  "scuffle_bytes_util::*",
+  "scuffle_workspace_hack::*",
+]

--- a/crates/ffmpeg/Cargo.toml
+++ b/crates/ffmpeg/Cargo.toml
@@ -82,9 +82,4 @@ allowed_external_types = [
   "tracing_test::*",
   "tracing_subscriber::*",
   "sha2::*",
-
-  # workspace-specific (safe to expose within the same ecosystem)
-  "scuffle_workspace_hack::*",
-  "nutype_enum::*",
-  "scuffle_mp4::*",
 ]

--- a/crates/ffmpeg/Cargo.toml
+++ b/crates/ffmpeg/Cargo.toml
@@ -63,3 +63,28 @@ always_include_features = [
 [package.metadata.docs.rs]
 features = ["channel", "tokio-channel", "crossbeam-channel", "tracing"]
 rustdoc-args = ["--cfg", "docsrs"]
+
+[package.metadata.cargo_check_external_types]
+allowed_external_types = [
+  # major released
+  "libc::*",
+  "bytes::*",
+  "tokio::*",
+  "crossbeam_channel::*",
+  "tracing::*",
+  "arc_swap::*",
+  "rusty_ffmpeg::*",
+  "rand::*",
+  "bon::*",
+  "thiserror::*",
+  "va_list::*",
+  "tempfile::*",
+  "tracing_test::*",
+  "tracing_subscriber::*",
+  "sha2::*",
+
+  # workspace-specific (safe to expose within the same ecosystem)
+  "scuffle_workspace_hack::*",
+  "nutype_enum::*",
+  "scuffle_mp4::*",
+]

--- a/crates/flv/Cargo.toml
+++ b/crates/flv/Cargo.toml
@@ -33,3 +33,23 @@ scuffle-workspace-hack.workspace = true
 
 [dev-dependencies]
 insta = "1.42"
+
+[package.metadata.cargo_check_external_types]
+allowed_external_types = [
+  # major released
+  "byteorder::*",
+  "bytes::*",
+  "num_traits::*",
+  "num_derive::*",
+  "thiserror::*",
+
+  # workspace-specific (safe to expose within the same ecosystem)
+  "scuffle_h264::*",
+  "scuffle_h265::*",
+  "scuffle_aac::*",
+  "scuffle_bytes_util::*",
+  "scuffle_av1::*",
+  "scuffle_amf0::*",
+  "nutype_enum::*",
+  "scuffle_workspace_hack::*",
+]

--- a/crates/flv/Cargo.toml
+++ b/crates/flv/Cargo.toml
@@ -42,14 +42,4 @@ allowed_external_types = [
   "num_traits::*",
   "num_derive::*",
   "thiserror::*",
-
-  # workspace-specific (safe to expose within the same ecosystem)
-  "scuffle_h264::*",
-  "scuffle_h265::*",
-  "scuffle_aac::*",
-  "scuffle_bytes_util::*",
-  "scuffle_av1::*",
-  "scuffle_amf0::*",
-  "nutype_enum::*",
-  "scuffle_workspace_hack::*",
 ]

--- a/crates/flv/src/lib.rs
+++ b/crates/flv/src/lib.rs
@@ -165,6 +165,7 @@ mod tests {
 
             insta::assert_debug_snapshot!(sps, @r"
             Sps {
+                test_change_for_semver_check: true,
                 nal_ref_idc: 3,
                 nal_unit_type: NALUnitType::SPS,
                 profile_idc: 100,

--- a/crates/future-ext/Cargo.toml
+++ b/crates/future-ext/Cargo.toml
@@ -13,3 +13,12 @@ keywords = ["future", "async", "await"]
 [dependencies]
 tokio = { version = "1", features = ["time"] }
 scuffle-workspace-hack.workspace = true
+
+[package.metadata.cargo_check_external_types]
+allowed_external_types = [
+  # major released
+  "tokio::*",
+
+  # workspace-specific (safe to expose within the same ecosystem)
+  "scuffle_workspace_hack::*",
+]

--- a/crates/future-ext/Cargo.toml
+++ b/crates/future-ext/Cargo.toml
@@ -18,7 +18,4 @@ scuffle-workspace-hack.workspace = true
 allowed_external_types = [
   # major released
   "tokio::*",
-
-  # workspace-specific (safe to expose within the same ecosystem)
-  "scuffle_workspace_hack::*",
 ]

--- a/crates/h264/Cargo.toml
+++ b/crates/h264/Cargo.toml
@@ -23,3 +23,16 @@ nutype-enum.workspace = true
 
 [dev-dependencies]
 insta = "1.42"
+
+[package.metadata.cargo_check_external_types]
+allowed_external_types = [
+  # major released
+  "bytes::*",
+  "byteorder::*",
+
+  # workspace-specific (safe to expose within the same ecosystem)
+  "scuffle_expgolomb::*",
+  "scuffle_bytes_util::*",
+  "scuffle_workspace_hack::*",
+  "nutype_enum::*",
+]

--- a/crates/h264/Cargo.toml
+++ b/crates/h264/Cargo.toml
@@ -29,10 +29,4 @@ allowed_external_types = [
   # major released
   "bytes::*",
   "byteorder::*",
-
-  # workspace-specific (safe to expose within the same ecosystem)
-  "scuffle_expgolomb::*",
-  "scuffle_bytes_util::*",
-  "scuffle_workspace_hack::*",
-  "nutype_enum::*",
 ]

--- a/crates/h264/src/sps/mod.rs
+++ b/crates/h264/src/sps/mod.rs
@@ -30,6 +30,8 @@ use crate::{EmulationPreventionIo, NALUnitType};
 /// ISO/IEC-14496-10-2022 - 7.3.2
 #[derive(Debug, Clone, PartialEq)]
 pub struct Sps {
+    /// Test temp field for semver-checks
+    pub test_change_for_semver_check: bool,
     /// The `nal_ref_idc` is comprised of 2 bits.
     ///
     /// A nonzero value means the NAL unit has any of the following: SPS, SPS extension,
@@ -508,6 +510,7 @@ impl Sps {
         }
 
         Ok(Sps {
+            test_change_for_semver_check: true,
             nal_ref_idc,
             nal_unit_type: NALUnitType(nal_unit_type),
             profile_idc,
@@ -886,6 +889,7 @@ mod tests {
 
         insta::assert_debug_snapshot!(result, @r"
         Sps {
+            test_change_for_semver_check: true,
             nal_ref_idc: 0,
             nal_unit_type: NALUnitType::SPS,
             profile_idc: 100,
@@ -1141,6 +1145,7 @@ mod tests {
 
         insta::assert_debug_snapshot!(result, @r"
         Sps {
+            test_change_for_semver_check: true,
             nal_ref_idc: 0,
             nal_unit_type: NALUnitType::SPS,
             profile_idc: 44,
@@ -1337,6 +1342,7 @@ mod tests {
 
         insta::assert_debug_snapshot!(result, @r"
         Sps {
+            test_change_for_semver_check: true,
             nal_ref_idc: 0,
             nal_unit_type: NALUnitType::SPS,
             profile_idc: 77,
@@ -1448,6 +1454,7 @@ mod tests {
 
         insta::assert_debug_snapshot!(result, @r"
         Sps {
+            test_change_for_semver_check: true,
             nal_ref_idc: 0,
             nal_unit_type: NALUnitType::SPS,
             profile_idc: 77,
@@ -1899,6 +1906,7 @@ mod tests {
 
         insta::assert_debug_snapshot!(result, @r"
         Sps {
+            test_change_for_semver_check: true,
             nal_ref_idc: 0,
             nal_unit_type: NALUnitType::SPS,
             profile_idc: 77,
@@ -2369,6 +2377,7 @@ mod tests {
 
         insta::assert_debug_snapshot!(reduced_result, @r"
         Sps {
+            test_change_for_semver_check: true,
             nal_ref_idc: 0,
             nal_unit_type: NALUnitType::SPS,
             profile_idc: 100,

--- a/crates/h265/Cargo.toml
+++ b/crates/h265/Cargo.toml
@@ -16,3 +16,15 @@ byteorder = "1.5"
 scuffle-expgolomb.workspace = true
 scuffle-bytes-util.workspace = true
 scuffle-workspace-hack.workspace = true
+
+[package.metadata.cargo_check_external_types]
+allowed_external_types = [
+  # major released
+  "bytes::*",
+  "byteorder::*",
+
+  # workspace-specific (safe to expose within the same ecosystem)
+  "scuffle_expgolomb::*",
+  "scuffle_bytes_util::*",
+  "scuffle_workspace_hack::*",
+]

--- a/crates/h265/Cargo.toml
+++ b/crates/h265/Cargo.toml
@@ -22,9 +22,4 @@ allowed_external_types = [
   # major released
   "bytes::*",
   "byteorder::*",
-
-  # workspace-specific (safe to expose within the same ecosystem)
-  "scuffle_expgolomb::*",
-  "scuffle_bytes_util::*",
-  "scuffle_workspace_hack::*",
 ]

--- a/crates/http/Cargo.toml
+++ b/crates/http/Cargo.toml
@@ -94,3 +94,31 @@ rustdoc-args = ["--cfg", "docsrs"]
 [package.metadata.xtask.powerset]
 additive-features = ["tracing", "tower"]
 ignore-features = ["http3"]
+
+[package.metadata.cargo_check_external_types]
+allowed_external_types = [
+  # major released
+  "tokio::*",
+  "thiserror::*",
+  "futures::*",
+  "bon::*",
+  "pin_project_lite::*",
+  "http::*",
+  "http_body::*",
+  "bytes::*",
+  "tracing::*",
+  "hyper::*",
+  "hyper_util::*",
+  "libc::*",
+  "quinn::*",
+  "h3_quinn::*",
+  "h3::*",
+  "tokio_rustls::*",
+  "rustls::*",
+  "tower::*",
+
+  # workspace-specific (safe to expose within the same ecosystem)
+  "scuffle_context::*",
+  "scuffle_workspace_hack::*",
+  "scuffle_future_ext::*",
+]

--- a/crates/http/Cargo.toml
+++ b/crates/http/Cargo.toml
@@ -116,9 +116,4 @@ allowed_external_types = [
   "tokio_rustls::*",
   "rustls::*",
   "tower::*",
-
-  # workspace-specific (safe to expose within the same ecosystem)
-  "scuffle_context::*",
-  "scuffle_workspace_hack::*",
-  "scuffle_future_ext::*",
 ]

--- a/crates/http/examples/Cargo.toml
+++ b/crates/http/examples/Cargo.toml
@@ -1,0 +1,31 @@
+[package]
+name = "scuffle-http-examples"
+version = "0.1.0"
+edition = "2024"
+publish = false
+repository = "https://github.com/scufflecloud/scuffle"
+authors = ["Scuffle <opensource@scuffle.cloud>"]
+readme = "README.md"
+documentation = "https://docs.rs/scuffle-http-examples"
+license = "MIT OR Apache-2.0"
+description = "Examples for scuffle-http"
+keywords = ["http", "server", "http1", "http2", "http3"]
+
+[[example]]
+name = "scuffle-http-axum"
+path = "src/axum.rs"
+
+[[example]]
+name = "scuffle-http-simple-service"
+path = "src/simple_service.rs"
+
+[dev-dependencies]
+axum = { version = "0.8.1", features = ["macros", "ws"] }
+tokio = { version = "1.43.0", features = ["macros", "rt-multi-thread"] }
+tracing = "0.1.41"
+tracing-subscriber = { version = "0.3.19", features = ["env-filter"] }
+rustls = "0.23.21"
+rustls-pemfile = "2.2.0"
+scuffle-http = { workspace = true, features = ["tls-rustls", "http3", "tracing"] }
+scuffle-workspace-hack.workspace = true
+

--- a/crates/metrics/Cargo.toml
+++ b/crates/metrics/Cargo.toml
@@ -57,3 +57,17 @@ additive-features = [
     "internal-logs",
     "default",
 ]
+
+[package.metadata.cargo_check_external_types]
+allowed_external_types = [
+  # major released
+  "prometheus_client::*",
+  "opentelemetry::*",
+  "opentelemetry_sdk::*",
+  "tracing::*",
+  "parking_lot::*",
+
+  # workspace-specific (safe to expose within the same ecosystem)
+  "scuffle_metrics_derive::*",
+  "scuffle_workspace_hack::*",
+]

--- a/crates/metrics/Cargo.toml
+++ b/crates/metrics/Cargo.toml
@@ -66,8 +66,4 @@ allowed_external_types = [
   "opentelemetry_sdk::*",
   "tracing::*",
   "parking_lot::*",
-
-  # workspace-specific (safe to expose within the same ecosystem)
-  "scuffle_metrics_derive::*",
-  "scuffle_workspace_hack::*",
 ]

--- a/crates/metrics/examples/Cargo.toml
+++ b/crates/metrics/examples/Cargo.toml
@@ -1,0 +1,26 @@
+[package]
+name = "scuffle-metrics-examples"
+version = "0.1.0"
+edition = "2024"
+publish = false
+repository = "https://github.com/scufflecloud/scuffle"
+authors = ["Scuffle <opensource@scuffle.cloud>"]
+readme = "README.md"
+license = "MIT OR Apache-2.0"
+
+[[example]]
+name = "scuffle-metrics-derive"
+path = "src/derive.rs"
+
+[[example]]
+name = "scuffle-metrics-prometheus"
+path = "src/prometheus.rs"
+
+[dependencies]
+scuffle-metrics.workspace = true
+opentelemetry-stdout = "0.29"
+opentelemetry_sdk = { version = "0.29", features = ["rt-tokio"] }
+opentelemetry = "0.29"
+prometheus-client = "0.23"
+tokio = { version = "1", features = ["full"] }
+scuffle-workspace-hack.workspace = true

--- a/crates/mp4/Cargo.toml
+++ b/crates/mp4/Cargo.toml
@@ -37,12 +37,4 @@ allowed_external_types = [
   "paste::*",
   "serde::*",
   "serde_json::*",
-
-  # workspace-specific (safe to expose within the same ecosystem)
-  "scuffle_h264::*",
-  "scuffle_h265::*",
-  "scuffle_av1::*",
-  "scuffle_aac::*",
-  "scuffle_bytes_util::*",
-  "scuffle_workspace_hack::*",
 ]

--- a/crates/mp4/Cargo.toml
+++ b/crates/mp4/Cargo.toml
@@ -27,3 +27,22 @@ scuffle-workspace-hack.workspace = true
 [dev-dependencies]
 serde = { version = "1", features = ["derive"] }
 serde_json = "1"
+
+[package.metadata.cargo_check_external_types]
+allowed_external_types = [
+  # major released
+  "byteorder::*",
+  "bytes::*",
+  "fixed::*",
+  "paste::*",
+  "serde::*",
+  "serde_json::*",
+
+  # workspace-specific (safe to expose within the same ecosystem)
+  "scuffle_h264::*",
+  "scuffle_h265::*",
+  "scuffle_av1::*",
+  "scuffle_aac::*",
+  "scuffle_bytes_util::*",
+  "scuffle_workspace_hack::*",
+]

--- a/crates/nutype_enum/Cargo.toml
+++ b/crates/nutype_enum/Cargo.toml
@@ -12,3 +12,9 @@ keywords = ["enum", "nutype"]
 
 [dependencies]
 scuffle-workspace-hack.workspace = true
+
+[package.metadata.cargo_check_external_types]
+allowed_external_types = [
+  # workspace-specific (safe to expose within the same ecosystem)
+  "scuffle_workspace_hack::*",
+]

--- a/crates/nutype_enum/Cargo.toml
+++ b/crates/nutype_enum/Cargo.toml
@@ -14,7 +14,4 @@ keywords = ["enum", "nutype"]
 scuffle-workspace-hack.workspace = true
 
 [package.metadata.cargo_check_external_types]
-allowed_external_types = [
-  # workspace-specific (safe to expose within the same ecosystem)
-  "scuffle_workspace_hack::*",
-]
+allowed_external_types = []

--- a/crates/postcompile/Cargo.toml
+++ b/crates/postcompile/Cargo.toml
@@ -29,3 +29,19 @@ insta = "1.42.0"
 
 [features]
 prettyplease = ["dep:prettyplease"]
+
+[package.metadata.cargo_check_external_types]
+allowed_external_types = [
+  # major released
+  "serde_json::*",
+  "cargo_metadata::*",
+  "cargo_platform::*",
+  "target_triple::*",
+  "serde_derive::*",
+  "serde::*",
+  "prettyplease::*",
+  "syn::*",
+
+  # workspace-specific (safe to expose within the same ecosystem)
+  "scuffle_workspace_hack::*",
+]

--- a/crates/postcompile/Cargo.toml
+++ b/crates/postcompile/Cargo.toml
@@ -41,7 +41,4 @@ allowed_external_types = [
   "serde::*",
   "prettyplease::*",
   "syn::*",
-
-  # workspace-specific (safe to expose within the same ecosystem)
-  "scuffle_workspace_hack::*",
 ]

--- a/crates/pprof/Cargo.toml
+++ b/crates/pprof/Cargo.toml
@@ -28,3 +28,14 @@ thiserror = "2"
 [dev-dependencies]
 # For examples:
 rand = "0.9"
+
+[package.metadata.cargo_check_external_types]
+allowed_external_types = [
+  # major released
+  "pprof::*",
+  "flate2::*",
+  "thiserror::*",
+
+  # workspace-specific (safe to expose within the same ecosystem)
+  "scuffle_workspace_hack::*",
+]

--- a/crates/pprof/Cargo.toml
+++ b/crates/pprof/Cargo.toml
@@ -35,7 +35,4 @@ allowed_external_types = [
   "pprof::*",
   "flate2::*",
   "thiserror::*",
-
-  # workspace-specific (safe to expose within the same ecosystem)
-  "scuffle_workspace_hack::*",
 ]

--- a/crates/pprof/examples/Cargo.toml
+++ b/crates/pprof/examples/Cargo.toml
@@ -1,0 +1,22 @@
+[package]
+name = "scuffle-pprof-examples"
+version = "0.1.0"
+edition = "2024"
+publish = false
+repository = "https://github.com/scufflecloud/scuffle"
+authors = ["Scuffle <opensource@scuffle.cloud>"]
+readme = "README.md"
+license = "MIT OR Apache-2.0"
+description = "Examples for the scuffle-pprof crate."
+keywords = ["pprof", "cpu"]
+
+[[example]]
+name = "scuffle-pprof-cpu"
+path = "src/cpu.rs"
+
+[dependencies]
+scuffle-pprof.workspace = true
+flate2 = "1.0"
+rand = "0.9"
+scuffle-workspace-hack.workspace = true
+

--- a/crates/rtmp/Cargo.toml
+++ b/crates/rtmp/Cargo.toml
@@ -48,3 +48,28 @@ serde_json = "1.0"
 tracing = "0.1.41"
 tracing-subscriber = "0.3.19"
 scuffle-flv = { workspace = true }
+
+[package.metadata.cargo_check_external_types]
+allowed_external_types = [
+  # major released
+  "byteorder::*",
+  "bytes::*",
+  "rand::*",
+  "hmac::*",
+  "sha2::*",
+  "uuid::*",
+  "chrono::*",
+  "num_traits::*",
+  "num_derive::*",
+  "tokio::*",
+  "futures::*",
+  "async_trait::*",
+  "tracing::*",
+  "serde_json::*",
+
+  # workspace-specific (safe to expose within the same ecosystem)
+  "scuffle_amf0::*",
+  "scuffle_workspace_hack::*",
+  "scuffle_bytes_util::*",
+  "scuffle_future_ext::*",
+]

--- a/crates/rtmp/Cargo.toml
+++ b/crates/rtmp/Cargo.toml
@@ -66,10 +66,4 @@ allowed_external_types = [
   "async_trait::*",
   "tracing::*",
   "serde_json::*",
-
-  # workspace-specific (safe to expose within the same ecosystem)
-  "scuffle_amf0::*",
-  "scuffle_workspace_hack::*",
-  "scuffle_bytes_util::*",
-  "scuffle_future_ext::*",
 ]

--- a/crates/settings/Cargo.toml
+++ b/crates/settings/Cargo.toml
@@ -62,3 +62,18 @@ additive-features = [
     "full",
     "bootstrap",
 ]
+
+[package.metadata.cargo_check_external_types]
+allowed_external_types = [
+  # major released
+  "config::*",
+  "clap::*",
+  "minijinja::*",
+  "serde::*",
+  "thiserror::*",
+  "anyhow::*",
+
+  # workspace-specific (safe to expose within the same ecosystem)
+  "scuffle_bootstrap::*",
+  "scuffle_workspace_hack::*",
+]

--- a/crates/settings/Cargo.toml
+++ b/crates/settings/Cargo.toml
@@ -72,8 +72,4 @@ allowed_external_types = [
   "serde::*",
   "thiserror::*",
   "anyhow::*",
-
-  # workspace-specific (safe to expose within the same ecosystem)
-  "scuffle_bootstrap::*",
-  "scuffle_workspace_hack::*",
 ]

--- a/crates/settings/examples/Cargo.toml
+++ b/crates/settings/examples/Cargo.toml
@@ -1,0 +1,21 @@
+[package]
+name = "scuffle-settings-examples"
+version = "0.1.0"
+edition = "2024"
+publish = false
+repository = "https://github.com/scufflecloud/scuffle"
+authors = ["Scuffle <opensource@scuffle.cloud>"]
+readme = "README.md"
+license = "MIT OR Apache-2.0"
+
+[[example]]
+name = "scuffle-settings-cli"
+path = "src/cli.rs"
+
+[dependencies]
+scuffle-settings = { workspace = true, features = ["cli"] }
+serde = "1"
+serde_derive = "1"
+smart-default = "0.7"
+scuffle-workspace-hack.workspace = true
+

--- a/crates/signal/Cargo.toml
+++ b/crates/signal/Cargo.toml
@@ -41,10 +41,4 @@ allowed_external_types = [
   "futures::*",
   "libc::*",
   "tokio_stream::*",
-
-  # workspace-specific (safe to expose within the same ecosystem)
-  "scuffle_bootstrap::*",
-  "scuffle_context::*",
-  "scuffle_workspace_hack::*",
-  "scuffle_future_ext::*",
 ]

--- a/crates/signal/Cargo.toml
+++ b/crates/signal/Cargo.toml
@@ -32,3 +32,19 @@ tokio-stream = { version = "0.1", features = ["sync"] }
 
 [features]
 bootstrap = ["scuffle-bootstrap", "scuffle-context", "anyhow", "tokio/macros"]
+
+[package.metadata.cargo_check_external_types]
+allowed_external_types = [
+  # major released
+  "tokio::*",
+  "anyhow::*",
+  "futures::*",
+  "libc::*",
+  "tokio_stream::*",
+
+  # workspace-specific (safe to expose within the same ecosystem)
+  "scuffle_bootstrap::*",
+  "scuffle_context::*",
+  "scuffle_workspace_hack::*",
+  "scuffle_future_ext::*",
+]

--- a/crates/transmuxer/Cargo.toml
+++ b/crates/transmuxer/Cargo.toml
@@ -27,3 +27,23 @@ scuffle-workspace-hack.workspace = true
 [dev-dependencies]
 serde = { version = "1.0", features = ["derive"] }
 serde_json = "1.0"
+
+[package.metadata.cargo_check_external_types]
+allowed_external_types = [
+  # major released
+  "byteorder::*",
+  "bytes::*",
+  "serde::*",
+  "serde_json::*",
+
+  # workspace-specific (safe to expose within the same ecosystem)
+  "scuffle_h264::*",
+  "scuffle_h265::*",
+  "scuffle_mp4::*",
+  "scuffle_aac::*",
+  "scuffle_av1::*",
+  "scuffle_flv::*",
+  "scuffle_amf0::*",
+  "scuffle_bytes_util::*",
+  "scuffle_workspace_hack::*",
+]

--- a/crates/transmuxer/Cargo.toml
+++ b/crates/transmuxer/Cargo.toml
@@ -35,15 +35,4 @@ allowed_external_types = [
   "bytes::*",
   "serde::*",
   "serde_json::*",
-
-  # workspace-specific (safe to expose within the same ecosystem)
-  "scuffle_h264::*",
-  "scuffle_h265::*",
-  "scuffle_mp4::*",
-  "scuffle_aac::*",
-  "scuffle_av1::*",
-  "scuffle_flv::*",
-  "scuffle_amf0::*",
-  "scuffle_bytes_util::*",
-  "scuffle_workspace_hack::*",
 ]

--- a/crates/workspace-hack/Cargo.toml
+++ b/crates/workspace-hack/Cargo.toml
@@ -6,8 +6,82 @@
 name = "scuffle-workspace-hack"
 version = "0.1.0"
 edition = "2024"
+publish = false
 description = "workspace-hack package, managed by hakari"
 license = "MIT OR Apache-2.0"
+
+[package.metadata.cargo_check_external_types]
+allowed_external_types = [
+  # major released
+  "axum::*",
+  "bitflags::*",
+  "byteorder::*",
+  "camino::*",
+  "chrono::*",
+  "clap::*",
+  "clap_builder::*",
+  "config::*",
+  "crossbeam_utils::*",
+  "digest::*",
+  "either::*",
+  "fastrand::*",
+  "futures::*",
+  "futures_channel::*",
+  "futures_core::*",
+  "futures_executor::*",
+  "futures_io::*",
+  "futures_sink::*",
+  "futures_task::*",
+  "futures_util::*",
+  "getrandom::*",
+  "hashbrown::*",
+  "hyper::*",
+  "hyper_util::*",
+  "insta::*",
+  "libc::*",
+  "log::*",
+  "memchr::*",
+  "num_traits::*",
+  "opentelemetry::*",
+  "opentelemetry_sdk::*",
+  "percent_encoding::*",
+  "prettyplease::*",
+  "proc_macro2::*",
+  "quote::*",
+  "rand::*",
+  "regex::*",
+  "regex_automata::*",
+  "regex_syntax::*",
+  "reqwest::*",
+  "rustls::*",
+  "rusty_ffmpeg::*",
+  "serde::*",
+  "serde_json::*",
+  "smallvec::*",
+  "syn::*",
+  "sync_wrapper::*",
+  "thiserror::*",
+  "tokio::*",
+  "tokio_util::*",
+  "tower::*",
+  "tracing::*",
+  "tracing_core::*",
+  "tracing_log::*",
+  "tracing_subscriber::*",
+
+  # platform-specific
+  "h3::*",
+  "h3_quinn::*",
+  "quinn::*",
+  "quinn_proto::*",
+  "quinn_udp::*",
+  "rustls_webpki::*",
+  "tokio_rustls::*",
+  "uuid::*",
+
+  # Windows-specific
+  "windows_sys::*",
+]
 
 # The parts of the file between the BEGIN HAKARI SECTION and END HAKARI SECTION comments
 # are managed by hakari.

--- a/dev-tools/xtask/Cargo.toml
+++ b/dev-tools/xtask/Cargo.toml
@@ -17,3 +17,4 @@ anyhow = "1.0"
 serde = { version = "1.0", features = ["derive"] }
 serde_json = "1.0"
 toml_edit = { version = "0.22", features = ["serde"] }
+regex = "1.11.1"

--- a/dev-tools/xtask/src/cmd/mod.rs
+++ b/dev-tools/xtask/src/cmd/mod.rs
@@ -3,6 +3,7 @@ use anyhow::Context;
 mod change_logs;
 mod dev_tools;
 mod power_set;
+mod semver_checks;
 mod workspace_deps;
 
 const IGNORED_PACKAGES: &[&str] = &["scuffle-workspace-hack", "xtask"];
@@ -15,6 +16,7 @@ pub enum Commands {
     #[clap(alias = "change-log", subcommand)]
     ChangeLogs(change_logs::Commands),
     DevTools(dev_tools::DevTools),
+    SemverChecks(semver_checks::SemverChecks),
 }
 
 impl Commands {
@@ -24,6 +26,7 @@ impl Commands {
             Commands::WorkspaceDeps(cmd) => cmd.run().context("workspace deps"),
             Commands::ChangeLogs(cmd) => cmd.run().context("change logs"),
             Commands::DevTools(cmd) => cmd.run().context("dev tools"),
+            Commands::SemverChecks(cmd) => cmd.run().context("semver checks"),
         }
     }
 }

--- a/dev-tools/xtask/src/cmd/semver_checks/mod.rs
+++ b/dev-tools/xtask/src/cmd/semver_checks/mod.rs
@@ -23,6 +23,9 @@ pub struct SemverChecks {
     /// Baseline git revision branch to compare against
     #[clap(long, default_value = "main")]
     baseline: String,
+
+    #[clap(long, default_value = "false")]
+    disable_hakari: bool,
 }
 
 impl SemverChecks {
@@ -46,6 +49,11 @@ impl SemverChecks {
             .collect();
 
         println!("Semver-checks will run on crates: {:?}", common_crates);
+
+        if self.disable_hakari {
+            println!("Disabling hakari");
+            cargo_cmd().args(["hakari", "disable"]).status().context("disabling hakari")?;
+        }
 
         for package in &common_crates {
             println!("Running semver-checks for {}", package);

--- a/dev-tools/xtask/src/cmd/semver_checks/mod.rs
+++ b/dev-tools/xtask/src/cmd/semver_checks/mod.rs
@@ -1,0 +1,83 @@
+use std::collections::HashSet;
+use std::path::PathBuf;
+
+use anyhow::{Context, Result};
+use clap::Parser;
+
+use crate::utils::{cargo_cmd, metadata};
+
+mod utils;
+
+use utils::{checkout_baseline, metadata_from_dir, workspace_crates_in_folder};
+
+/// Semver-checks can run in two ways:
+/// 1. Provide a baseline git revision branch to compare against, such as `main`:
+///    `cargo xtask semver-checks --baseline-rev main`
+///
+/// 2. Provide a hash to compare against:
+///    `cargo xtask semver-checks --baseline-hash some_hash`
+///
+/// By default, cargo-semver-checks will run against the `main` branch.
+#[derive(Debug, Clone, Parser)]
+pub struct SemverChecks {
+    /// Baseline git revision branch to compare against
+    #[clap(long, default_value = "main")]
+    baseline_rev: String,
+
+    #[clap(long)]
+    /// If provided, explicitly sets the baseline commit hash, skipping lookup
+    baseline_hash: Option<String>,
+}
+
+impl SemverChecks {
+    pub fn run(self) -> Result<()> {
+        let current_metadata = metadata().context("current metadata")?;
+        let current_crates_set = workspace_crates_in_folder(&current_metadata, "crates");
+
+        let tmp_dir = PathBuf::from("target/semver-baseline");
+
+        match self.baseline_hash {
+            Some(hash) => {
+                println!("Using explicitly provided commit hash: {}", hash);
+                checkout_baseline(&hash, &tmp_dir).context("checking out baseline by hash")?;
+            }
+            None => {
+                checkout_baseline(&self.baseline_rev, &tmp_dir).context("checking out baseline")?;
+            }
+        };
+
+        let baseline_metadata = metadata_from_dir(&tmp_dir).context("baseline metadata")?;
+        let baseline_crates_set = workspace_crates_in_folder(&baseline_metadata, &tmp_dir.join("crates").to_string_lossy());
+
+        let common_crates: HashSet<_> = current_metadata
+            .packages
+            .iter()
+            .map(|p| p.name.clone())
+            .filter(|name| current_crates_set.contains(name) && baseline_crates_set.contains(name))
+            .collect();
+
+        println!("Semver-checks will run on crates: {:?}", common_crates);
+
+        for package in &common_crates {
+            println!("Running semver-checks for {}", package);
+            let status = cargo_cmd()
+                .args([
+                    "semver-checks",
+                    "check-release",
+                    "--package",
+                    package,
+                    "--baseline-root",
+                    tmp_dir.to_str().unwrap(),
+                    "--all-features",
+                ])
+                .status()
+                .context("running semver-checks")?;
+
+            if !status.success() {
+                anyhow::bail!("Semver check failed for crate '{}'", package);
+            }
+        }
+
+        Ok(())
+    }
+}

--- a/dev-tools/xtask/src/cmd/semver_checks/mod.rs
+++ b/dev-tools/xtask/src/cmd/semver_checks/mod.rs
@@ -1,36 +1,30 @@
 use std::collections::HashSet;
 use std::path::PathBuf;
+use std::process::Stdio;
 
 use anyhow::{Context, Result};
 use clap::Parser;
+use regex::Regex;
 
 use crate::utils::{cargo_cmd, metadata};
 
 mod utils;
-
 use utils::{checkout_baseline, metadata_from_dir, workspace_crates_in_folder};
 
-/// Semver-checks can run in two ways:
-/// 1. Provide a baseline git revision branch to compare against, such as `main`:
-///    `cargo xtask semver-checks --baseline main`
-///
-/// 2. Provide a hash to compare against:
-///    `cargo xtask semver-checks --baseline some_hash`
-///
-/// By default, cargo-semver-checks will run against the `main` branch.
 #[derive(Debug, Clone, Parser)]
 pub struct SemverChecks {
     /// Baseline git revision branch to compare against
     #[clap(long, default_value = "main")]
     baseline: String,
 
+    /// Disable hakari
     #[clap(long, default_value = "false")]
     disable_hakari: bool,
 }
 
 impl SemverChecks {
     pub fn run(self) -> Result<()> {
-        let current_metadata = metadata().context("current metadata")?;
+        let current_metadata = metadata().context("getting current metadata")?;
         let current_crates_set = workspace_crates_in_folder(&current_metadata, "crates");
 
         let tmp_dir = PathBuf::from("target/semver-baseline");
@@ -38,7 +32,7 @@ impl SemverChecks {
         // Checkout baseline (auto-cleanup on Drop)
         let _worktree_cleanup = checkout_baseline(&self.baseline, &tmp_dir).context("checking out baseline")?;
 
-        let baseline_metadata = metadata_from_dir(&tmp_dir).context("baseline metadata")?;
+        let baseline_metadata = metadata_from_dir(&tmp_dir).context("getting baseline metadata")?;
         let baseline_crates_set = workspace_crates_in_folder(&baseline_metadata, &tmp_dir.join("crates").to_string_lossy());
 
         let common_crates: HashSet<_> = current_metadata
@@ -55,26 +49,139 @@ impl SemverChecks {
             cargo_cmd().args(["hakari", "disable"]).status().context("disabling hakari")?;
         }
 
-        for package in &common_crates {
-            println!("Running semver-checks for {}", package);
-            let status = cargo_cmd()
-                .args([
-                    "semver-checks",
-                    "check-release",
-                    "--package",
-                    package,
-                    "--baseline-root",
-                    tmp_dir.to_str().unwrap(),
-                    "--all-features",
-                ])
-                .status()
-                .context("running semver-checks")?;
+        let mut args = vec![
+            "semver-checks",
+            "check-release",
+            "--baseline-root",
+            tmp_dir.to_str().unwrap(),
+            "--all-features",
+        ];
 
-            if !status.success() {
-                anyhow::bail!("Semver check failed for crate '{}'", package);
+        for package in &common_crates {
+            args.push("--package");
+            args.push(package);
+        }
+
+        let output = cargo_cmd()
+            .env("CARGO_TERM_COLOR", "never")
+            .args(&args)
+            .stdout(Stdio::piped())
+            .stderr(Stdio::piped())
+            .output()
+            .context("running semver-checks")?;
+
+        let mut semver_output = String::new();
+        semver_output.push_str(&String::from_utf8_lossy(&output.stdout));
+        semver_output.push_str(&String::from_utf8_lossy(&output.stderr));
+
+        if semver_output.trim().is_empty() {
+            anyhow::bail!("No semver-checks output received. The command may have failed.");
+        }
+
+        // empty print to separate from "info: contents updated"
+        println!();
+
+        // Regex to capture "Checking" lines (ignoring leading whitespace).
+        // Supports both formats:
+        //   "Checking <crate> vX.Y.Z (current)"
+        //   "Checking <crate> vX.Y.Z -> vX.Y.Z (no change)"
+        let check_re = Regex::new(r"^Checking\s+(?P<crate>\S+)\s+v(?P<curr>\d+\.\d+\.\d+)(?:\s+->\s+v\d+\.\d+\.\d+)?")
+            .context("compiling check regex")?;
+
+        // Regex for summary lines that indicate an update is required.
+        // Example:
+        //   "Summary semver requires new major version: 1 major and 0 minor checks failed"
+        let summary_re = Regex::new(r"^Summary semver requires new (?P<update_type>major|minor) version:")
+            .context("compiling summary regex")?;
+
+        let mut current_crate: Option<(String, String)> = None;
+        let mut summary: Vec<String> = Vec::new();
+        let mut description: Vec<String> = Vec::new();
+        let mut error_count = 0;
+
+        let mut lines = semver_output.lines().peekable();
+        while let Some(line) = lines.next() {
+            let trimmed = line.trim_start();
+
+            if trimmed.starts_with("Checking") {
+                // Capture crate name and version without printing.
+                if let Some(caps) = check_re.captures(trimmed) {
+                    let crate_name = caps.name("crate").unwrap().as_str().to_string();
+                    let current_version = caps.name("curr").unwrap().as_str().to_string();
+                    current_crate = Some((crate_name, current_version));
+                }
+            } else if trimmed.starts_with("Summary") {
+                if let Some(caps) = summary_re.captures(trimmed) {
+                    let update_type = caps.name("update_type").unwrap().as_str();
+                    if let Some((crate_name, current_version)) = current_crate.take() {
+                        let new_version = new_version_number(&current_version, update_type)?;
+                        summary.push(format!("⚠️ -> {} update required for `{}`.", update_type, crate_name));
+                        summary.push(format!(
+                            "🛠️ -> Please update the version from {} to {}.",
+                            current_version, new_version
+                        ));
+                        error_count += 1;
+
+                        summary.push(format!("🔖 Error #{error_count}"));
+                        summary.append(&mut description);
+                        // add a new line after the description
+                        summary.push("".to_string());
+                    }
+                }
+            } else if trimmed.starts_with("---") {
+                for desc_line in lines.by_ref() {
+                    let desc_trimmed = desc_line.trim_start();
+
+                    if desc_trimmed.starts_with("Checking")
+                        || desc_trimmed.starts_with("Built")
+                        || desc_trimmed.starts_with("Building")
+                        || desc_trimmed.starts_with("Parsing")
+                        || desc_trimmed.starts_with("Parsed")
+                        || desc_trimmed.starts_with("Finished")
+                        || desc_trimmed.starts_with("Summary")
+                    {
+                        break;
+                    }
+                    // store the lines into a separate vec
+                    description.push(desc_trimmed.to_string());
+                }
             }
         }
 
+        // Print deferred update and failure block messages.
+        if error_count > 0 {
+            println!("\n🚩 --- {} ERROR(S) FOUND --- 🚩", error_count);
+
+            for line in summary {
+                println!("{}", line);
+            }
+
+            println!("\n🚩 --- END OF ERROR OUTPUT --- 🚩");
+        } else {
+            println!("✅ No errors found! ✅");
+        }
+
+        // print an empty line to separate output from worktree cleanup line
+        println!();
+
         Ok(())
     }
+}
+
+fn new_version_number(version: &str, update_type: &str) -> Result<String> {
+    let version = version.strip_prefix('v').unwrap_or(version);
+    let mut parts: Vec<u64> = version
+        .split('.')
+        .map(|s| s.parse::<u64>())
+        .collect::<Result<_, _>>()
+        .context("parsing version numbers")?;
+    if parts.len() != 3 {
+        anyhow::bail!("expected version format vX.Y.Z, got: {}", version);
+    }
+    match update_type {
+        "minor" => parts[2] += 1,
+        "major" => parts[1] += 1,
+        _ => anyhow::bail!("Failed to parse update type: {update_type}"),
+    }
+    Ok(format!("v{}.{}.{}", parts[0], parts[1], parts[2]))
 }

--- a/dev-tools/xtask/src/cmd/semver_checks/utils.rs
+++ b/dev-tools/xtask/src/cmd/semver_checks/utils.rs
@@ -1,0 +1,80 @@
+use std::collections::HashSet;
+use std::path::Path;
+use std::process::Command;
+
+use anyhow::{Context, Result};
+use cargo_metadata::{Metadata, MetadataCommand};
+
+pub fn metadata_from_dir(dir: impl AsRef<Path>) -> Result<Metadata> {
+    MetadataCommand::new()
+        .manifest_path(dir.as_ref().join("Cargo.toml"))
+        .exec()
+        .context("fetching cargo metadata from directory")
+}
+
+pub fn checkout_baseline(baseline_rev_or_hash: &str, target_dir: &Path) -> Result<()> {
+    if target_dir.exists() {
+        std::fs::remove_dir_all(target_dir)?;
+    }
+
+    // Attempt to resolve the revision locally first
+    let rev_parse_output = Command::new("git")
+        .args(["rev-parse", "--verify", baseline_rev_or_hash])
+        .output()
+        .context("git rev-parse failed")?;
+
+    let commit_hash = if rev_parse_output.status.success() {
+        String::from_utf8(rev_parse_output.stdout)?.trim().to_string()
+    } else {
+        // If not found locally, fetch it explicitly from origin
+        println!("Revision {} not found locally. Fetching from origin...", baseline_rev_or_hash);
+
+        Command::new("git")
+            .args(["fetch", "--depth", "1", "origin", baseline_rev_or_hash])
+            .status()
+            .context("git fetch failed")?
+            .success()
+            .then_some(())
+            .context("git fetch unsuccessful")?;
+
+        // Retry resolving after fetch
+        let retry_output = Command::new("git")
+            .args(["rev-parse", "--verify", "FETCH_HEAD"])
+            .output()
+            .context("git rev-parse after fetch failed")?;
+
+        retry_output
+            .status
+            .success()
+            .then(|| String::from_utf8(retry_output.stdout).unwrap().trim().to_string())
+            .context(format!("Failed to resolve revision {}", baseline_rev_or_hash))?
+    };
+
+    println!("Checking out commit {} into {:?}", commit_hash, target_dir);
+
+    Command::new("git")
+        .args(["worktree", "add", "--detach", target_dir.to_str().unwrap(), &commit_hash])
+        .status()
+        .context("git worktree add failed")?
+        .success()
+        .then_some(())
+        .context("git worktree add unsuccessful")
+}
+
+pub fn workspace_crates_in_folder(meta: &Metadata, folder: &str) -> HashSet<String> {
+    let folder_path = std::fs::canonicalize(folder).expect("folder should exist");
+
+    meta.packages
+        .iter()
+        .filter(|p| {
+            // All crate examples have publish = false.
+            // The scuffle-bootstrap-derive crate doesn't work with the semver-checks tool at the moment.
+            let manifest_path = p.manifest_path.parent().unwrap();
+            manifest_path.starts_with(&folder_path)
+                && p.publish.as_ref().map(|v| !v.is_empty()).unwrap_or(true)
+                && p.name != "scuffle-bootstrap-derive"
+                && p.name != "scuffle-metrics-derive"
+        })
+        .map(|p| p.name.clone())
+        .collect()
+}


### PR DESCRIPTION
Adds:

- semver-checks to CI.

- ~~cargo check external types to each crate's cargo.toml.~~

CLOUD-55

~~CLOUD-81~~

This pr only adds the current external types to each crate's cargo.toml, but it doesn't check for each external type.