### PR TITLE
add new labels for release prs

### DIFF
--- a/.github/labels.yaml
+++ b/.github/labels.yaml
@@ -30,3 +30,7 @@
   color: "ffffff"
 - name: "change-log-not-required"
   color: "ffffff"
+- name: "release"
+  color: "32a852"
+- name: "automated"
+  color: "a62b33"

--- a/.github/workflows/cargo-release-pr.yaml
+++ b/.github/workflows/cargo-release-pr.yaml
@@ -51,6 +51,7 @@ jobs:
           title: Automated release of ${{ inputs.crate }}
           body-path: /tmp/pr-body.txt
           branch: create-release/${{ inputs.crate }}
+          labels: release,automated,change-log-not-required
           commit-message: |
             Automated release of ${{ inputs.crate }}
 


### PR DESCRIPTION
Adds a `release` and a `automated` label for the release prs generated via ci. We also attach the `no-changelog-required` label to the PR since it wont include a changelog.
