### PR TITLE
improve ffmpeg API

### DIFF
--- a/changes.d/pr-303.toml
+++ b/changes.d/pr-303.toml
@@ -1,0 +1,29 @@
+[[scuffle-ffmpeg]]
+category = "fix"
+description = "`VideoFrame` and `AudioFrame` are now valid upon instantiation, using the `builder` method on each"
+breaking = true
+authors = ["@Juliapixel"]
+
+[[scuffle-ffmpeg]]
+category = "fix"
+description = "`VideoFrame` data accesses no longer cause undefined behavior and respect inverse iteration order"
+breaking = true
+authors = ["@Juliapixel"]
+
+[[scuffle-ffmpeg]]
+category = "fix"
+description = "`VideoFrame::set_width` and `VideoFrame::set_height` were removed due to a soundness hole"
+breaking = true
+authors = ["@Juliapixel"]
+
+[[scuffle-ffmpeg]]
+category = "feat"
+description = "`AudioFrame` data is now accessible via the `data` and `data_mut` methods"
+breaking = false
+authors = ["@Juliapixel"]
+
+[[scuffle-ffmpeg]]
+category = "feat"
+description = "new `Resampler` type exposes `libswresample` functionality"
+breaking = false
+authors = ["@Juliapixel"]

--- a/crates/ffmpeg/src/filter_graph.rs
+++ b/crates/ffmpeg/src/filter_graph.rs
@@ -543,10 +543,7 @@ mod tests {
             .sample_fmt(AVSampleFormat::S16)
             .nb_samples(1024)
             .sample_rate(44100)
-            .channel_layout(
-                AudioChannelLayout::new(2)
-                    .expect("Failed to create a new AudioChannelLayout")
-            )
+            .channel_layout(AudioChannelLayout::new(2).expect("Failed to create a new AudioChannelLayout"))
             .build()
             .expect("Failed to create a new AudioFrame");
 

--- a/crates/ffmpeg/src/filter_graph.rs
+++ b/crates/ffmpeg/src/filter_graph.rs
@@ -603,8 +603,8 @@ mod tests {
 
         // create frame w/ mismatched format and sample rate
         let mut frame = GenericFrame::new().expect("Failed to create frame");
-        // Safety: frame was not yet allocated
-        unsafe { frame.set_format(AVSampleFormat::Fltp.into()) };
+        // Safety: frame was not yet allocated and inner pointer is valid
+        unsafe { frame.as_mut_ptr().as_mut().unwrap().format = AVSampleFormat::Fltp.into() };
         let result = source_context.send_frame(&frame);
 
         assert!(result.is_err(), "send_frame should fail when sending an invalid frame");

--- a/crates/ffmpeg/src/frame.rs
+++ b/crates/ffmpeg/src/frame.rs
@@ -727,7 +727,7 @@ impl std::ops::DerefMut for AudioFrame {
 #[cfg_attr(all(test, coverage_nightly), coverage(off))]
 mod tests {
     use insta::assert_debug_snapshot;
-    use rand::{thread_rng, Rng};
+    use rand::{rng, Rng};
 
     use crate::frame::{AudioChannelLayout, AudioFrame, GenericFrame, VideoFrame};
     use crate::rational::Rational;
@@ -870,7 +870,7 @@ mod tests {
                 let data_slice = data.get_row_mut(row as usize).unwrap();
                 randomized_data.push(
                     (0..data_slice.len())
-                        .map(|_| thread_rng().gen()) // generate random data
+                        .map(|_| rng().random()) // generate random data
                         .collect(),
                 );
                 data_slice.copy_from_slice(&randomized_data[row as usize]); // copy random data to the frame

--- a/crates/ffmpeg/src/frame.rs
+++ b/crates/ffmpeg/src/frame.rs
@@ -1163,4 +1163,23 @@ mod tests {
         })
         .is_err());
     }
+
+    #[test]
+    fn frame_data_write() {
+        let data: &mut [u8] = &mut [1, 2, 3, 4, 5, 6];
+
+        let mut frame_data = FrameData {
+            ptr: core::ptr::NonNull::new(data.as_mut_ptr()).unwrap(),
+            linesize: 3,
+            height: 2,
+        };
+
+        for i in 1..frame_data.len() {
+            frame_data[i] = frame_data[0]
+        }
+
+        for i in 0..frame_data.len() {
+            assert_eq!(frame_data[i], 1, "all bytes of frame_data should be 0")
+        }
+    }
 }

--- a/crates/ffmpeg/src/frame.rs
+++ b/crates/ffmpeg/src/frame.rs
@@ -400,12 +400,16 @@ impl VideoFrame {
     }
 
     /// Sets the width of the frame.
-    pub const fn set_width(&mut self, width: usize) {
+    ///
+    /// Safety: this must only ever be called before data allocation
+    pub(crate) const unsafe fn set_width(&mut self, width: usize) {
         self.0 .0.as_deref_mut_except().width = width as i32;
     }
 
     /// Sets the height of the frame.
-    pub const fn set_height(&mut self, height: usize) {
+    ///
+    /// Safety: this must only ever be called before data allocation
+    pub(crate) const unsafe fn set_height(&mut self, height: usize) {
         self.0 .0.as_deref_mut_except().height = height as i32;
     }
 

--- a/crates/ffmpeg/src/frame.rs
+++ b/crates/ffmpeg/src/frame.rs
@@ -222,49 +222,49 @@ impl GenericFrame {
         AudioFrame(self)
     }
 
-    /// Returns the presentation timestamp of the frame.
-    pub(crate) const fn pts(&self) -> Option<i64> {
+    /// Returns the presentation timestamp of the frame, in `time_base` units.
+    pub const fn pts(&self) -> Option<i64> {
         check_i64(self.0.as_deref_except().pts)
     }
 
-    /// Sets the presentation timestamp of the frame.
-    pub(crate) const fn set_pts(&mut self, pts: Option<i64>) {
+    /// Sets the presentation timestamp of the frame, in `time_base` units.
+    pub const fn set_pts(&mut self, pts: Option<i64>) {
         self.0.as_deref_mut_except().pts = or_nopts(pts);
         self.0.as_deref_mut_except().best_effort_timestamp = or_nopts(pts);
     }
 
-    /// Returns the duration of the frame.
-    pub(crate) const fn duration(&self) -> Option<i64> {
+    /// Returns the duration of the frame, in `time_base` units.
+    pub const fn duration(&self) -> Option<i64> {
         check_i64(self.0.as_deref_except().duration)
     }
 
-    /// Sets the duration of the frame.
-    pub(crate) const fn set_duration(&mut self, duration: Option<i64>) {
+    /// Sets the duration of the frame, in `time_base` units.
+    pub const fn set_duration(&mut self, duration: Option<i64>) {
         self.0.as_deref_mut_except().duration = or_nopts(duration);
     }
 
-    /// Returns the best effort timestamp of the frame.
-    pub(crate) const fn best_effort_timestamp(&self) -> Option<i64> {
+    /// Returns the best effort timestamp of the frame, in `time_base` units.
+    pub const fn best_effort_timestamp(&self) -> Option<i64> {
         check_i64(self.0.as_deref_except().best_effort_timestamp)
     }
 
-    /// Returns the decoding timestamp of the frame.
-    pub(crate) const fn dts(&self) -> Option<i64> {
+    /// Returns the decoding timestamp of the frame, in `time_base` units.
+    pub const fn dts(&self) -> Option<i64> {
         check_i64(self.0.as_deref_except().pkt_dts)
     }
 
-    /// Sets the decoding timestamp of the frame.
+    /// Sets the decoding timestamp of the frame, in `time_base` units.
     pub(crate) const fn set_dts(&mut self, dts: Option<i64>) {
         self.0.as_deref_mut_except().pkt_dts = or_nopts(dts);
     }
 
     /// Returns the time base of the frame.
-    pub(crate) fn time_base(&self) -> Rational {
+    pub fn time_base(&self) -> Rational {
         self.0.as_deref_except().time_base.into()
     }
 
     /// Sets the time base of the frame.
-    pub(crate) fn set_time_base(&mut self, time_base: impl Into<Rational>) {
+    pub fn set_time_base(&mut self, time_base: impl Into<Rational>) {
         self.0.as_deref_mut_except().time_base = time_base.into().into();
     }
 
@@ -291,8 +291,8 @@ impl GenericFrame {
         self.0.as_deref_except().width != 0
     }
 
-    /// Returns the linesize of the frame.
-    pub(crate) const fn linesize(&self, index: usize) -> Option<i32> {
+    /// Returns the linesize of the frame, in bytes.
+    pub const fn linesize(&self, index: usize) -> Option<i32> {
         if index >= self.0.as_deref_except().linesize.len() {
             return None;
         }
@@ -328,6 +328,7 @@ impl VideoFrame {
         #[builder(default = AV_NOPTS_VALUE)] dts: i64,
         #[builder(default = 0)] duration: i64,
         #[builder(default = Rational::ZERO)] time_base: Rational,
+        /// Alignment of the underlying data buffers, set to 0 for automatic.
         #[builder(default = 0)] alignment: i32,
     ) -> Result<Self, FfmpegError> {
         if width <= 0 || height <= 0 {
@@ -597,6 +598,7 @@ impl AudioFrame {
         #[builder(default = AV_NOPTS_VALUE)] pts: i64,
         #[builder(default = AV_NOPTS_VALUE)] dts: i64,
         #[builder(default = Rational::ZERO)] time_base: Rational,
+        /// Alignment of the underlying data buffers, set to 0 for automatic.
         #[builder(default = 0)] alignment: i32,
     ) -> Result<Self, FfmpegError> {
         if sample_rate <= 0 || nb_samples <= 0 {

--- a/crates/ffmpeg/src/lib.rs
+++ b/crates/ffmpeg/src/lib.rs
@@ -239,7 +239,9 @@ pub mod log;
 pub mod packet;
 /// Rational number specific functionality.
 pub mod rational;
-/// Scalar specific functionality.
+/// [`AudioFrame`] resampling and format conversion.
+pub mod resampler;
+/// Scaler specific functionality.
 pub mod scaler;
 /// Stream specific functionality.
 pub mod stream;

--- a/crates/ffmpeg/src/lib.rs
+++ b/crates/ffmpeg/src/lib.rs
@@ -239,7 +239,7 @@ pub mod log;
 pub mod packet;
 /// Rational number specific functionality.
 pub mod rational;
-/// [`AudioFrame`] resampling and format conversion.
+/// [`frame::AudioFrame`] resampling and format conversion.
 pub mod resampler;
 /// Scaler specific functionality.
 pub mod scaler;

--- a/crates/ffmpeg/src/rational.rs
+++ b/crates/ffmpeg/src/rational.rs
@@ -20,6 +20,8 @@ impl Default for Rational {
 impl Rational {
     /// The zero rational number.
     pub const ZERO: Rational = Rational::static_new::<0, 1>();
+    /// The one rational number.
+    pub const ONE: Rational = Rational::static_new::<1, 1>();
 
     /// Create a new rational number.
     pub const fn new(numerator: i32, denominator: NonZero<i32>) -> Self {

--- a/crates/ffmpeg/src/rational.rs
+++ b/crates/ffmpeg/src/rational.rs
@@ -18,10 +18,10 @@ impl Default for Rational {
 }
 
 impl Rational {
-    /// The zero rational number.
-    pub const ZERO: Rational = Rational::static_new::<0, 1>();
     /// The one rational number.
     pub const ONE: Rational = Rational::static_new::<1, 1>();
+    /// The zero rational number.
+    pub const ZERO: Rational = Rational::static_new::<0, 1>();
 
     /// Create a new rational number.
     pub const fn new(numerator: i32, denominator: NonZero<i32>) -> Self {

--- a/crates/ffmpeg/src/resampler.rs
+++ b/crates/ffmpeg/src/resampler.rs
@@ -131,10 +131,7 @@ mod tests {
         // Safety: swr_is_initialized is safe to call
         let is_init = unsafe { swr_is_initialized(resampler.ptr.as_mut_ptr()) };
 
-        assert!(
-            is_init.is_positive() && is_init != 0,
-            "Resampler is not initialized"
-        )
+        assert!(is_init.is_positive() && is_init != 0, "Resampler is not initialized")
     }
 
     #[test]

--- a/crates/ffmpeg/src/resampler.rs
+++ b/crates/ffmpeg/src/resampler.rs
@@ -98,7 +98,7 @@ impl Resampler {
 #[cfg(test)]
 #[cfg_attr(all(test, coverage_nightly), coverage(off))]
 mod tests {
-    use rand::{thread_rng, Rng};
+    use rand::{rng, Rng};
     use rusty_ffmpeg::ffi::swr_is_initialized;
 
     use crate::{
@@ -166,7 +166,7 @@ mod tests {
             .expect("Failed to create input AudioFrame");
 
         let input_data = input_frame.data_mut(0).expect("Data buffer of input frame was invalid");
-        thread_rng().fill(input_data);
+        rng().fill(input_data);
 
         let output = resampler.process(&input_frame).expect("Failed to process frame");
 

--- a/crates/ffmpeg/src/resampler.rs
+++ b/crates/ffmpeg/src/resampler.rs
@@ -1,11 +1,9 @@
 use rusty_ffmpeg::ffi::{swr_alloc_set_opts2, swr_convert_frame, swr_free, swr_init, SwrContext};
 
-use crate::{
-    enums::AVSampleFormat,
-    error::{FfmpegError, FfmpegErrorCode},
-    frame::{AudioChannelLayout, AudioFrame, GenericFrame},
-    smart_object::SmartPtr,
-};
+use crate::enums::AVSampleFormat;
+use crate::error::{FfmpegError, FfmpegErrorCode};
+use crate::frame::{AudioChannelLayout, AudioFrame, GenericFrame};
+use crate::smart_object::SmartPtr;
 
 /// A wrapper around an [`SwrContext`]. Which is used to resample and convert [`AudioFrame`]s.
 pub struct Resampler {
@@ -101,12 +99,9 @@ mod tests {
     use rand::{rng, Rng};
     use rusty_ffmpeg::ffi::swr_is_initialized;
 
-    use crate::{
-        frame::{AudioChannelLayout, AudioFrame},
-        AVSampleFormat,
-    };
-
     use super::Resampler;
+    use crate::frame::{AudioChannelLayout, AudioFrame};
+    use crate::AVSampleFormat;
 
     #[test]
     fn test_resampler_new() {

--- a/crates/ffmpeg/src/resampler.rs
+++ b/crates/ffmpeg/src/resampler.rs
@@ -1,0 +1,178 @@
+use rusty_ffmpeg::ffi::{swr_alloc_set_opts2, swr_convert_frame, swr_free, swr_init, SwrContext};
+
+use crate::{
+    enums::AVSampleFormat,
+    error::{FfmpegError, FfmpegErrorCode},
+    frame::{AudioChannelLayout, AudioFrame, GenericFrame},
+    smart_object::SmartPtr,
+};
+
+/// A wrapper around an [`SwrContext`]. Which is used to resample and convert [`AudioFrame`]s.
+pub struct Resampler {
+    ptr: SmartPtr<SwrContext>,
+    channel_layout: AudioChannelLayout,
+    sample_fmt: AVSampleFormat,
+    sample_rate: i32,
+}
+
+impl Resampler {
+    /// Create a new [`Resampler`] instance
+    pub fn new(
+        input_ch_layout: AudioChannelLayout,
+        input_sample_fmt: AVSampleFormat,
+        input_sample_rate: i32,
+        output_ch_layout: AudioChannelLayout,
+        output_sample_fmt: AVSampleFormat,
+        output_sample_rate: i32,
+    ) -> Result<Self, FfmpegError> {
+        let mut ptr = core::ptr::null_mut::<SwrContext>();
+
+        // Safety: swr_alloc_set_opts2 is safe to call
+        FfmpegErrorCode(unsafe {
+            swr_alloc_set_opts2(
+                &mut ptr,
+                output_ch_layout.as_ptr(),
+                output_sample_fmt.into(),
+                output_sample_rate,
+                input_ch_layout.as_ptr(),
+                input_sample_fmt.into(),
+                input_sample_rate,
+                0,
+                core::ptr::null::<core::ffi::c_void>() as _,
+            )
+        })
+        .result()?;
+
+        let destructor = |ctx: &mut *mut SwrContext| {
+            // Safety: swr_free is safe to call
+            unsafe { swr_free(ctx) };
+        };
+
+        // Safety: this is safe to call
+        let mut ptr = unsafe { SmartPtr::wrap_non_null(ptr, destructor).ok_or(FfmpegError::Alloc) }?;
+
+        // Safety: ptr is initialized, swr_init is safe to call
+        FfmpegErrorCode(unsafe { swr_init(ptr.as_mut_ptr()) }).result()?;
+
+        Ok(Self {
+            ptr,
+            channel_layout: output_ch_layout,
+            sample_fmt: output_sample_fmt,
+            sample_rate: output_sample_rate,
+        })
+    }
+
+    /// Process an [`AudioFrame`] thought the resampler
+    pub fn process(&mut self, input: &AudioFrame) -> Result<AudioFrame, FfmpegError> {
+        let mut out = GenericFrame::new()?;
+
+        // Safety: the GenericFrame is allocated
+        let inner = unsafe { out.as_mut_ptr().as_mut() }.expect("inner pointer of GenericFrame was invalid");
+        inner.ch_layout = self.channel_layout().copy()?.into_inner();
+        inner.format = self.sample_format().into();
+        inner.sample_rate = self.sample_rate();
+
+        // Safety: self.ptr is initialized and valid, data buffers of out get initialized here, swr_convert_frame is safe to call
+        FfmpegErrorCode(unsafe { swr_convert_frame(self.ptr.as_mut_ptr(), out.as_mut_ptr(), input.as_ptr()) }).result()?;
+
+        // Safety: swr_convert_frame was successful, the pointer is valid;
+        Ok(out.audio())
+    }
+
+    /// The output channel layout
+    pub const fn channel_layout(&self) -> &AudioChannelLayout {
+        &self.channel_layout
+    }
+
+    /// The output sample format
+    pub const fn sample_format(&self) -> AVSampleFormat {
+        self.sample_fmt
+    }
+
+    /// The output sample rate
+    pub const fn sample_rate(&self) -> i32 {
+        self.sample_rate
+    }
+}
+
+#[cfg(test)]
+#[cfg_attr(all(test, coverage_nightly), coverage(off))]
+mod tests {
+    use rand::{thread_rng, Rng};
+    use rusty_ffmpeg::ffi::swr_is_initialized;
+
+    use crate::{
+        frame::{AudioChannelLayout, AudioFrame},
+        AVSampleFormat,
+    };
+
+    use super::Resampler;
+
+    #[test]
+    fn test_resampler_new() {
+        let input_layout = AudioChannelLayout::new(1).expect("Failed to create new AudioChannelLayout");
+        let input_format = AVSampleFormat::S16;
+        let input_sample_rate = 44100;
+
+        let output_layout = AudioChannelLayout::new(2).expect("Failed to create new AudioChannelLayout");
+        let output_format = AVSampleFormat::S16p;
+        let output_sample_rate = 48000;
+
+        let mut resampler = Resampler::new(
+            input_layout,
+            input_format,
+            input_sample_rate,
+            output_layout,
+            output_format,
+            output_sample_rate,
+        )
+        .expect("Failed to create new Resampler");
+
+        // Safety: swr_is_initialized is safe to call
+        let is_init = unsafe { swr_is_initialized(resampler.ptr.as_mut_ptr()) };
+
+        assert!(
+            is_init.is_positive() && is_init != 0,
+            "Resampler is not initialized"
+        )
+    }
+
+    #[test]
+    fn test_resampler_process() {
+        let input_layout = AudioChannelLayout::new(1).expect("Failed to create new AudioChannelLayout");
+        let input_format = AVSampleFormat::S16;
+        let input_sample_rate = 44100;
+
+        let output_layout = AudioChannelLayout::new(2).expect("Failed to create new AudioChannelLayout");
+        let output_format = AVSampleFormat::S16p;
+        let output_sample_rate = 48000;
+
+        let mut resampler = Resampler::new(
+            input_layout.copy().unwrap(),
+            input_format,
+            input_sample_rate,
+            output_layout,
+            output_format,
+            output_sample_rate,
+        )
+        .expect("Failed to create new Resampler");
+
+        let mut input_frame = AudioFrame::builder()
+            .nb_samples(1024)
+            .channel_layout(input_layout)
+            .sample_fmt(input_format)
+            .sample_rate(44100)
+            .build()
+            .expect("Failed to create input AudioFrame");
+
+        let input_data = input_frame.data_mut(0).expect("Data buffer of input frame was invalid");
+        thread_rng().fill(input_data);
+
+        let output = resampler.process(&input_frame).expect("Failed to process frame");
+
+        assert_eq!(output.channel_count(), 2, "Output channel count should be 2");
+        assert!(output.data(0).is_some(), "First data buffer of output frame is None");
+        assert!(output.data(1).is_some(), "Second data buffer of output frame is None");
+        assert_eq!(output.sample_rate(), 48000, "Output sample rate was not 48000");
+    }
+}

--- a/crates/ffmpeg/src/scaler.rs
+++ b/crates/ffmpeg/src/scaler.rs
@@ -194,7 +194,7 @@ mod tests {
             if let Some(mut data_buf) = input_frame.data_mut(data_idx as usize) {
                 for row_idx in 0..data_buf.height() {
                     let row = data_buf.get_row_mut(row_idx as usize).unwrap();
-                    rand::thread_rng().fill(row);
+                    rng.fill(row);
                 }
             }
         }

--- a/crates/ffmpeg/src/scaler.rs
+++ b/crates/ffmpeg/src/scaler.rs
@@ -54,14 +54,11 @@ impl VideoScaler {
         // Safety: `ptr` is a valid pointer & `destructor` has been setup to free the context.
         let ptr = unsafe { SmartPtr::wrap_non_null(ptr, destructor) }.ok_or(FfmpegError::Alloc)?;
 
-        let mut frame = VideoFrame::new()?;
-
-        frame.set_width(width as usize);
-        frame.set_height(height as usize);
-        frame.set_format(pixel_format.into());
-
-        // Safety: `av_frame_get_buffer` is safe to call.
-        unsafe { frame.alloc_frame_buffer(Some(32)) }.expect("Failed to allocate frame buffer");
+        let frame = VideoFrame::builder()
+            .width(width)
+            .height(height)
+            .pix_fmt(pixel_format)
+            .build()?;
 
         Ok(Self {
             ptr,
@@ -183,38 +180,23 @@ mod tests {
         )
         .expect("Failed to create Scalar");
 
-        let mut input_frame: VideoFrame = VideoFrame::new().expect("Failed to create Frame");
-        // Safety: `input_frame` is a valid pointer
-        input_frame.set_width(input_width as usize);
-        input_frame.set_height(input_height as usize);
-        input_frame.set_format(incoming_pixel_fmt.into());
-
-        // Safety: `av_frame_get_buffer` is safe to call.
-        unsafe { input_frame.alloc_frame_buffer(Some(32)) }.expect("Failed to allocate frame buffer");
+        let mut input_frame = VideoFrame::builder()
+            .width(input_width)
+            .height(input_height)
+            .pix_fmt(incoming_pixel_fmt)
+            .build()
+            .expect("Failed to create VideoFrame");
 
         // We need to fill the buffer with random data otherwise the result will be based off uninitialized data.
         let mut rng = rand::rng();
 
-        for y in 0..input_height {
-            // Safety: `frame_mut.data[0]` is a valid pointer
-            let y = (y * input_frame.linesize(0).unwrap()) as usize;
-            let row = &mut input_frame.data_mut(0).unwrap()[y..y + input_width as usize];
-            rng.fill(row);
-        }
-
-        let half_height = (input_height + 1) / 2;
-        let half_width = (input_width + 1) / 2;
-
-        for y in 0..half_height {
-            let y = (y * input_frame.linesize(1).unwrap()) as usize;
-            let row = &mut input_frame.data_mut(1).unwrap()[y..y + half_width as usize];
-            rng.fill(row);
-        }
-
-        for y in 0..half_height {
-            let y = (y * input_frame.linesize(2).unwrap()) as usize;
-            let row = &mut input_frame.data_mut(2).unwrap()[y..y + half_width as usize];
-            rng.fill(row);
+        for data_idx in 0..rusty_ffmpeg::ffi::AV_NUM_DATA_POINTERS {
+            if let Some(mut data_buf) = input_frame.data_mut(data_idx as usize) {
+                for row_idx in 0..data_buf.height() {
+                    let row = data_buf.get_row_mut(row_idx as usize).unwrap();
+                    rand::thread_rng().fill(row);
+                }
+            }
         }
 
         let result = scalar.process(&input_frame);
@@ -231,7 +213,7 @@ mod tests {
             width: 1280,
             height: 720,
             sample_aspect_ratio: Rational {
-                numerator: 0,
+                numerator: 1,
                 denominator: 1,
             },
             pts: None,


### PR DESCRIPTION
- fixes potential undefined behavior when using frame types
- makes creating and using frame types easier
  - interpreting and manipulating pixel and sample data is still unwieldy and requires user intervention, often with unsafe code
- new `Resampler` type, with `libswresample` functionality