### PR TITLE
add ignore for RUSTSEC-2025-0007

### DIFF
--- a/crates/http/Cargo.toml
+++ b/crates/http/Cargo.toml
@@ -35,7 +35,7 @@ hyper-util = { version = "0.1.10", default-features = false, features = ["server
 libc = { version = "0.2.169", default-features = false, optional = true }
 
 # QUIC + HTTP/3
-quinn = { version = "0.11.6", default-features = false, features = ["platform-verifier", "runtime-tokio", "rustls-ring", "aws-lc-rs"], optional = true }
+quinn = { version = "0.11.6", default-features = false, features = ["platform-verifier", "runtime-tokio", "rustls-aws-lc-rs"], optional = true }
 h3-quinn = { version = "0.0.7", default-features = false, optional = true }
 h3 = { version = "0.0.6", default-features = false, optional = true }
 

--- a/crates/workspace-hack/Cargo.toml
+++ b/crates/workspace-hack/Cargo.toml
@@ -56,7 +56,7 @@ regex = { version = "1", default-features = false, features = ["std", "unicode"]
 regex-automata = { version = "0.4", default-features = false, features = ["meta", "std", "unicode"] }
 regex-syntax = { version = "0.8", default-features = false, features = ["std", "unicode"] }
 reqwest = { version = "0.12", default-features = false, features = ["http2", "http3", "rustls-tls"] }
-rustls = { version = "0.23", features = ["ring"] }
+rustls = { version = "0.23", features = ["aws-lc-rs"] }
 rusty_ffmpeg = { version = "0.16", default-features = false, features = ["link_system_ffmpeg", "link_vcpkg_ffmpeg"] }
 serde = { version = "1", features = ["alloc", "derive"] }
 serde_json = { version = "1", features = ["raw_value", "unbounded_depth"] }
@@ -119,7 +119,7 @@ regex = { version = "1", default-features = false, features = ["std", "unicode"]
 regex-automata = { version = "0.4", default-features = false, features = ["meta", "std", "unicode"] }
 regex-syntax = { version = "0.8", default-features = false, features = ["std", "unicode"] }
 reqwest = { version = "0.12", default-features = false, features = ["http2", "http3", "rustls-tls"] }
-rustls = { version = "0.23", features = ["ring"] }
+rustls = { version = "0.23", features = ["aws-lc-rs"] }
 rusty_ffmpeg = { version = "0.16", default-features = false, features = ["link_system_ffmpeg", "link_vcpkg_ffmpeg"] }
 serde = { version = "1", features = ["alloc", "derive"] }
 serde_json = { version = "1", features = ["raw_value", "unbounded_depth"] }
@@ -145,9 +145,10 @@ h3-quinn = { version = "0.0.7", default-features = false, features = ["tracing"]
 hyper = { version = "1", default-features = false, features = ["client"] }
 hyper-util = { version = "0.1", default-features = false, features = ["client-legacy"] }
 once_cell = { version = "1" }
-quinn = { version = "0.11", default-features = false, features = ["aws-lc-rs", "futures-io", "log", "platform-verifier", "runtime-tokio", "rustls"] }
-quinn-proto = { version = "0.11", default-features = false, features = ["aws-lc-rs", "log", "platform-verifier", "rustls-ring"] }
+quinn = { version = "0.11", default-features = false, features = ["futures-io", "log", "platform-verifier", "runtime-tokio", "rustls", "rustls-aws-lc-rs"] }
+quinn-proto = { version = "0.11", default-features = false, features = ["log", "platform-verifier", "rustls-aws-lc-rs", "rustls-ring"] }
 quinn-udp = { version = "0.5", default-features = false, features = ["log"] }
+rustls = { version = "0.23", default-features = false, features = ["ring"] }
 rustls-webpki = { version = "0.102", default-features = false, features = ["aws_lc_rs", "ring", "std"] }
 tokio-rustls = { version = "0.26", default-features = false, features = ["aws_lc_rs", "logging", "ring", "tls12"] }
 tower = { version = "0.5", default-features = false, features = ["timeout"] }
@@ -159,9 +160,10 @@ h3-quinn = { version = "0.0.7", default-features = false, features = ["tracing"]
 hyper = { version = "1", default-features = false, features = ["client"] }
 hyper-util = { version = "0.1", default-features = false, features = ["client-legacy"] }
 once_cell = { version = "1" }
-quinn = { version = "0.11", default-features = false, features = ["aws-lc-rs", "futures-io", "log", "platform-verifier", "runtime-tokio", "rustls"] }
-quinn-proto = { version = "0.11", default-features = false, features = ["aws-lc-rs", "log", "platform-verifier", "rustls-ring"] }
+quinn = { version = "0.11", default-features = false, features = ["futures-io", "log", "platform-verifier", "runtime-tokio", "rustls", "rustls-aws-lc-rs"] }
+quinn-proto = { version = "0.11", default-features = false, features = ["log", "platform-verifier", "rustls-aws-lc-rs", "rustls-ring"] }
 quinn-udp = { version = "0.5", default-features = false, features = ["log"] }
+rustls = { version = "0.23", default-features = false, features = ["ring"] }
 rustls-webpki = { version = "0.102", default-features = false, features = ["aws_lc_rs", "ring", "std"] }
 tokio-rustls = { version = "0.26", default-features = false, features = ["aws_lc_rs", "logging", "ring", "tls12"] }
 tower = { version = "0.5", default-features = false, features = ["timeout"] }
@@ -174,9 +176,10 @@ hyper = { version = "1", default-features = false, features = ["client"] }
 hyper-util = { version = "0.1", default-features = false, features = ["client-legacy"] }
 num-traits = { version = "0.2", default-features = false, features = ["i128"] }
 once_cell = { version = "1" }
-quinn = { version = "0.11", default-features = false, features = ["aws-lc-rs", "futures-io", "log", "platform-verifier", "runtime-tokio", "rustls"] }
-quinn-proto = { version = "0.11", default-features = false, features = ["aws-lc-rs", "log", "platform-verifier", "rustls-ring"] }
+quinn = { version = "0.11", default-features = false, features = ["futures-io", "log", "platform-verifier", "runtime-tokio", "rustls", "rustls-aws-lc-rs"] }
+quinn-proto = { version = "0.11", default-features = false, features = ["log", "platform-verifier", "rustls-aws-lc-rs", "rustls-ring"] }
 quinn-udp = { version = "0.5", default-features = false, features = ["log"] }
+rustls = { version = "0.23", default-features = false, features = ["ring"] }
 rustls-webpki = { version = "0.102", default-features = false, features = ["aws_lc_rs", "ring", "std"] }
 tokio-rustls = { version = "0.26", default-features = false, features = ["aws_lc_rs", "logging", "ring", "tls12"] }
 tower = { version = "0.5", default-features = false, features = ["timeout"] }
@@ -189,9 +192,10 @@ hyper = { version = "1", default-features = false, features = ["client"] }
 hyper-util = { version = "0.1", default-features = false, features = ["client-legacy"] }
 num-traits = { version = "0.2", default-features = false, features = ["i128"] }
 once_cell = { version = "1" }
-quinn = { version = "0.11", default-features = false, features = ["aws-lc-rs", "futures-io", "log", "platform-verifier", "runtime-tokio", "rustls"] }
-quinn-proto = { version = "0.11", default-features = false, features = ["aws-lc-rs", "log", "platform-verifier", "rustls-ring"] }
+quinn = { version = "0.11", default-features = false, features = ["futures-io", "log", "platform-verifier", "runtime-tokio", "rustls", "rustls-aws-lc-rs"] }
+quinn-proto = { version = "0.11", default-features = false, features = ["log", "platform-verifier", "rustls-aws-lc-rs", "rustls-ring"] }
 quinn-udp = { version = "0.5", default-features = false, features = ["log"] }
+rustls = { version = "0.23", default-features = false, features = ["ring"] }
 rustls-webpki = { version = "0.102", default-features = false, features = ["aws_lc_rs", "ring", "std"] }
 tokio-rustls = { version = "0.26", default-features = false, features = ["aws_lc_rs", "logging", "ring", "tls12"] }
 tower = { version = "0.5", default-features = false, features = ["timeout"] }

--- a/deny.toml
+++ b/deny.toml
@@ -27,4 +27,10 @@ license-files = [
 ]
 
 [advisories]
-ignore = []
+ignore = [
+    # ring is unmaintained
+    # we do not use ring for anything except for http3 testing in scuffle-http.
+    # Unfortunately reqwest uses ring for http3.
+    # See https://github.com/seanmonstar/reqwest/issues/2566
+    "RUSTSEC-2025-0007",
+]


### PR DESCRIPTION
ring is unmaintained
we do not use ring for anything except for http3 testing in scuffle-http. Unfortunately reqwest uses ring for http3.
See https://github.com/seanmonstar/reqwest/issues/2566