### PR TITLE
fix missed test case in h264 pr

### DIFF
--- a/crates/flv/src/lib.rs
+++ b/crates/flv/src/lib.rs
@@ -237,8 +237,9 @@ mod tests {
             assert_eq!(avc_decoder_configuration_record.pps.len(), 1);
             assert_eq!(avc_decoder_configuration_record.extended_config, None);
 
-            let sps = Sps::parse(&mut std::io::Cursor::new(&avc_decoder_configuration_record.sps[0]))
-                .expect("expected sequence parameter set");
+            let sps =
+                Sps::parse_with_emulation_prevention(&mut std::io::Cursor::new(&avc_decoder_configuration_record.sps[0]))
+                    .expect("expected sequence parameter set");
 
             insta::assert_debug_snapshot!(sps, @r"
             Sps {
@@ -288,8 +289,8 @@ mod tests {
                 chroma_sample_loc: None,
                 timing_info: Some(
                     TimingInfo {
-                        num_units_in_tick: 48,
-                        time_scale: 16777216,
+                        num_units_in_tick: 1,
+                        time_scale: 120,
                     },
                 ),
             }

--- a/crates/h264/README.md
+++ b/crates/h264/README.md
@@ -45,7 +45,7 @@ let result = AVCDecoderConfigurationRecord::parse(&mut io::Cursor::new(data.into
 // Do something with it!
 
 // You can also access the sps bytestream and parse it:
-let sps = Sps::parse(&result.sps[0]).unwrap();
+let sps = Sps::parse_with_emulation_prevention(&result.sps[0]).unwrap();
 ```
 
 For more examples, check out the tests in the source code for the parse function.


### PR DESCRIPTION
In the test we incorrectly use `Sps::parse` and instead should be using `Sps::parse_with_emulation_prevention`. Also corrects the README.md docs to do the same.
