### PR TITLE
Implement callbacks to configure the sockets used as listeners

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3042,6 +3042,7 @@ dependencies = [
  "scuffle-context",
  "scuffle-future-ext",
  "scuffle-workspace-hack",
+ "socket2",
  "thiserror 2.0.12",
  "tokio",
  "tokio-rustls",

--- a/crates/http/Cargo.toml
+++ b/crates/http/Cargo.toml
@@ -20,6 +20,7 @@ futures = { version = "0.3.31", default-features = false, features = ["alloc"]}
 bon = "3.3.2"
 pin-project-lite = "0.2.16"
 scuffle-context.workspace = true
+socket2 = "0.5.8"
 
 # HTTP parsing
 http = "1.2.0"

--- a/crates/http/src/backend/hyper/mod.rs
+++ b/crates/http/src/backend/hyper/mod.rs
@@ -8,6 +8,7 @@ use tracing::Instrument;
 
 use crate::error::Error;
 use crate::service::{HttpService, HttpServiceFactory};
+use crate::server::ConfigureSocketCallback;
 
 mod handler;
 mod stream;
@@ -33,6 +34,8 @@ pub struct HyperBackend<F> {
     /// Use `[::]` for a dual-stack listener.
     /// For example, use `[::]:80` to bind to port 80 on both IPv4 and IPv6.
     bind: SocketAddr,
+    /// Callback to configure socket
+    configure_sock: Option<ConfigureSocketCallback>,
     /// rustls config.
     ///
     /// Use this field to set the server into TLS mode.
@@ -79,7 +82,27 @@ where
         }
 
         // We have to create an std listener first because the tokio listener isn't clonable
-        let listener = tokio::net::TcpListener::bind(self.bind).await?.into_std()?;
+        let listener = {
+            let mut sock = socket2::Socket::new(
+                match self.bind {
+                    SocketAddr::V4(_) => socket2::Domain::IPV4,
+                    SocketAddr::V6(_) => socket2::Domain::IPV6,
+                },
+                socket2::Type::STREAM,
+                Some(socket2::Protocol::TCP),
+            )?;
+
+            sock.set_nonblocking(true)?;
+            sock.set_only_v6(false)?;
+            if let Some(cfg_fn) = self.configure_sock.as_ref() {
+                sock = cfg_fn.call(sock)?;
+            }
+
+            sock.bind(&socket2::SockAddr::from(self.bind))?;
+            sock.listen(128)?;
+
+            std::net::TcpListener::from(sock)
+        };
 
         #[cfg(feature = "tls-rustls")]
         let tls_acceptor = self

--- a/crates/http/src/lib.rs
+++ b/crates/http/src/lib.rs
@@ -82,7 +82,7 @@ pub mod service;
 
 pub use http;
 pub use http::Response;
-pub use server::{HttpServer, HttpServerBuilder};
+pub use server::{HttpServer, HttpServerBuilder, ConfigureSocketCallback};
 
 /// An incoming request.
 pub type IncomingRequest = http::Request<body::IncomingBody>;


### PR DESCRIPTION
Hello, i have recently come across a situation where i wanted to use SO_REUSEPORT on the HttpServers. 
I added options to the HttpServerBuilder that can be set to callbacks which can configure `socket2::Socket` instances that will then be used as listeners.