### PR TITLE
deny trash crates

### DIFF
--- a/deny.toml
+++ b/deny.toml
@@ -34,3 +34,9 @@ ignore = [
 
 [bans]
 multiple-versions = "allow"
+deny = [
+    # AI Fork of serde_yaml
+    "serde_yml",
+    # AI Fork of paste
+    "pastey",
+]


### PR DESCRIPTION
Starts the deny list disallowing crates into our repo.

We start by denying
- `serde_yml` a shitty ai fork of `serde_yaml`
- `pastey` a shitty ai fork of `paste`

Seems to be a common trend that when dtolnay marks a crate as unmaintained, someone forks it and starts adding slop using ai.

