### PR TITLE
docs(http): improve examples

### DIFF
--- a/crates/http/examples/Cargo.toml
+++ b/crates/http/examples/Cargo.toml
@@ -11,12 +11,16 @@ description = "Examples for scuffle-http"
 keywords = ["http", "server", "http1", "http2", "http3"]
 
 [[example]]
-name = "scuffle-http-axum"
-path = "src/axum.rs"
+name = "scuffle-http-echo"
+path = "src/echo.rs"
 
 [[example]]
-name = "scuffle-http-simple-service"
-path = "src/simple_service.rs"
+name = "scuffle-http-echo-tls"
+path = "src/echo_tls.rs"
+
+[[example]]
+name = "scuffle-http-axum"
+path = "src/axum.rs"
 
 [dev-dependencies]
 axum = { version = "0.8.1", features = ["macros", "ws"] }

--- a/crates/http/examples/README.md
+++ b/crates/http/examples/README.md
@@ -2,8 +2,9 @@
 
 Examples of using the `scuffle-http` crate.
 
-- [axum](./src/axum.rs) - Example of creating a cpu profile.
-- [simple_service](./src/simple_service.rs) - Example of creating a server which hosts a simple service.
+- [echo](./src/echo.rs) - A simple echo server.
+- [echo-tls](./src/echo_tls.rs) - A simple echo server with encryption (HTTPS) and HTTP/3.
+- [axum](./src/axum.rs) - Example of using the `axum` web framework with `scuffle-http`.
 
 ## Status
 

--- a/crates/http/examples/src/echo.rs
+++ b/crates/http/examples/src/echo.rs
@@ -1,0 +1,31 @@
+//! A simple HTTP echo server.
+//!
+//! This example demonstrates how to create a simple HTTP server that echoes the request body back to the client.
+//!
+//! Try with:
+//!
+//! ```
+//! curl -X POST -d 'test' http://localhost:8000/
+//! ```
+
+#[tokio::main]
+async fn main() {
+    let service = scuffle_http::service::fn_http_service(|req| async move {
+        scuffle_http::Response::builder()
+            .status(scuffle_http::http::StatusCode::OK)
+            .body(req.into_body())
+    });
+    // The simplest option here is a clone factory that clones the given service for each connection.
+    let service_factory = scuffle_http::service::service_clone_factory(service);
+
+    // Create a server that listens on all interfaces on port 8000.
+    // By default, the server supports unencrypted HTTP/1 and HTTP/2. (no HTTPS)
+    // For an HTTPS example, see the `scuffle-http-echo-tls` example.
+    scuffle_http::HttpServer::builder()
+        .service_factory(service_factory)
+        .bind("[::]:8000".parse().unwrap())
+        .build()
+        .run()
+        .await
+        .expect("server failed");
+}


### PR DESCRIPTION
- Add echo examples to `scuffle-http` because it's the classic server example

CLOUD-96