### PR TITLE
fix clippy warning from nightly

### DIFF
--- a/crates/http/src/server.rs
+++ b/crates/http/src/server.rs
@@ -251,7 +251,7 @@ where
 
                     let hyper = std::pin::pin!(builder.build().run());
 
-                    let mut http3 = crate::backend::h3::Http3Backend::builder()
+                    let http3 = crate::backend::h3::Http3Backend::builder()
                         .ctx(self.ctx)
                         .worker_tasks(self.worker_tasks)
                         .service_factory(self.service_factory)


### PR DESCRIPTION
Nightly got bumped and caused an update in clippy. 
I suspect in 2024 edition the behaviour around the pin! macro changed because I believe you used to require the variable be mut before using the macro. 