### PR TITLE
chore: new nightly clippy lint

### DIFF
--- a/crates/aac/src/lib.rs
+++ b/crates/aac/src/lib.rs
@@ -229,7 +229,7 @@ mod tests {
         ];
 
         for (idx, freq) in cases {
-            assert_eq!(freq, idx.to_freq(), "Expected frequency for {:?}", idx);
+            assert_eq!(freq, idx.to_freq(), "Expected frequency for {idx:?}");
         }
     }
 }

--- a/crates/bootstrap/examples/cli.rs
+++ b/crates/bootstrap/examples/cli.rs
@@ -63,7 +63,7 @@ impl scuffle_bootstrap::global::Global for Global {
     }
 
     async fn on_service_exit(self: &Arc<Self>, name: &'static str, result: anyhow::Result<()>) -> anyhow::Result<()> {
-        println!("service exited: {}", name);
+        println!("service exited: {name}");
         result
     }
 }

--- a/crates/bytes-util/src/bit_read.rs
+++ b/crates/bytes-util/src/bit_read.rs
@@ -225,8 +225,7 @@ mod tests {
             assert_eq!(
                 reader.read_bit().unwrap(),
                 (binary & (1 << (31 - i))) != 0,
-                "bit {} is not correct",
-                i
+                "bit {i} is not correct"
             );
         }
 
@@ -253,8 +252,7 @@ mod tests {
             assert_eq!(
                 reader.read_bits(count).ok(),
                 Some(expected),
-                "reading {} bits ({i}) are not correct",
-                count
+                "reading {count} bits ({i}) are not correct"
             );
         }
 
@@ -269,7 +267,7 @@ mod tests {
             let pos = reader.data.stream_position().unwrap();
             assert_eq!(pos, i, "stream pos");
             assert_eq!(reader.bit_pos(), 0, "bit pos");
-            assert!(reader.read_bit().unwrap(), "bit {} is not correct", i);
+            assert!(reader.read_bit().unwrap(), "bit {i} is not correct");
             reader.align().unwrap();
             let pos = reader.data.stream_position().unwrap();
             assert_eq!(pos, i + 1, "stream pos");

--- a/crates/bytes-util/src/cow/string/mod.rs
+++ b/crates/bytes-util/src/cow/string/mod.rs
@@ -297,19 +297,19 @@ mod tests {
     #[test]
     fn display() {
         let cow = StringCow::from_ref("hello");
-        let fmt = format!("{}", cow);
+        let fmt = format!("{cow}");
         assert_eq!(fmt, "hello");
 
         let cow = StringCow::from_static("hello");
-        let fmt = format!("{}", cow);
+        let fmt = format!("{cow}");
         assert_eq!(fmt, "hello");
 
         let cow = StringCow::from_string(String::from("world"));
-        let fmt = format!("{}", cow);
+        let fmt = format!("{cow}");
         assert_eq!(fmt, "world");
 
         let cow = StringCow::from_bytes(ByteString::from_static("foo"));
-        let fmt = format!("{}", cow);
+        let fmt = format!("{cow}");
         assert_eq!(fmt, "foo");
     }
 }

--- a/crates/ffmpeg/src/codec.rs
+++ b/crates/ffmpeg/src/codec.rs
@@ -156,7 +156,7 @@ mod tests {
     #[test]
     fn test_decoder_codec_debug_null() {
         let decoder_codec = DecoderCodec::empty();
-        let debug_output = format!("{:?}", decoder_codec);
+        let debug_output = format!("{decoder_codec:?}");
 
         insta::assert_snapshot!(debug_output, @r#"DecoderCodec { name: "null", id: AVCodecID::None }"#);
     }
@@ -164,7 +164,7 @@ mod tests {
     #[test]
     fn test_decoder_codec_debug_non_null() {
         let decoder_codec = DecoderCodec::new(AVCodecID::H264).expect("H264 codec should be available");
-        let debug_output = format!("{:?}", decoder_codec);
+        let debug_output = format!("{decoder_codec:?}");
 
         insta::assert_snapshot!(debug_output, @r#"DecoderCodec { name: "h264", id: 27 }"#);
     }
@@ -286,8 +286,7 @@ mod tests {
 
         assert!(
             result.is_none(),
-            "Expected None for an invalid encoder name {}",
-            invalid_encoder_name
+            "Expected None for an invalid encoder name {invalid_encoder_name}"
         );
     }
 

--- a/crates/ffmpeg/src/consts.rs
+++ b/crates/ffmpeg/src/consts.rs
@@ -66,7 +66,7 @@ mod tests {
         let value = vec![1, 2, 3];
         let mut_value = Mut::new(value);
 
-        assert_eq!(format!("{:?}", mut_value), "[1, 2, 3]");
+        assert_eq!(format!("{mut_value:?}"), "[1, 2, 3]");
     }
 
     #[test]

--- a/crates/ffmpeg/src/decoder.rs
+++ b/crates/ffmpeg/src/decoder.rs
@@ -490,7 +490,7 @@ mod tests {
         if let Err(err) = decoder_result {
             match err {
                 crate::error::FfmpegError::NoDecoder => (),
-                _ => panic!("Unexpected error type: {:?}", err),
+                _ => panic!("Unexpected error type: {err:?}"),
             }
         }
     }
@@ -516,7 +516,7 @@ mod tests {
         if let Err(err) = decoder_result {
             match err {
                 crate::error::FfmpegError::NoDecoder => (),
-                _ => panic!("Unexpected error type: {:?}", err),
+                _ => panic!("Unexpected error type: {err:?}"),
             }
         }
     }

--- a/crates/ffmpeg/src/encoder.rs
+++ b/crates/ffmpeg/src/encoder.rs
@@ -733,24 +733,20 @@ mod tests {
             .expect("Failed to create encoder");
 
         let stream_index = encoder.stream_index();
-        assert_eq!(stream_index, 0, "Unexpected stream index: expected 0, got {}", stream_index);
+        assert_eq!(stream_index, 0, "Unexpected stream index: expected 0, got {stream_index}");
 
         let actual_incoming_time_base = encoder.incoming_time_base();
         assert_eq!(
             actual_incoming_time_base,
             incoming_time_base.into(),
-            "Unexpected incoming_time_base: expected {:?}, got {:?}",
-            incoming_time_base,
-            actual_incoming_time_base
+            "Unexpected incoming_time_base: expected {incoming_time_base:?}, got {actual_incoming_time_base:?}"
         );
 
         let actual_outgoing_time_base = encoder.outgoing_time_base();
         assert_eq!(
             actual_outgoing_time_base,
             outgoing_time_base.into(),
-            "Unexpected outgoing_time_base: expected {:?}, got {:?}",
-            outgoing_time_base,
-            actual_outgoing_time_base
+            "Unexpected outgoing_time_base: expected {outgoing_time_base:?}, got {actual_outgoing_time_base:?}"
         );
     }
 

--- a/crates/ffmpeg/src/filter_graph.rs
+++ b/crates/ffmpeg/src/filter_graph.rs
@@ -353,8 +353,7 @@ mod tests {
         let filter_ptr = unsafe { avfilter_get_by_name(CString::new(filter_name).unwrap().as_ptr()) };
         assert!(
             !filter_ptr.is_null(),
-            "avfilter_get_by_name should return a valid pointer for filter '{}'",
-            filter_name
+            "avfilter_get_by_name should return a valid pointer for filter '{filter_name}'"
         );
 
         // Safety: The pointer here is valid.
@@ -384,8 +383,7 @@ mod tests {
         let filter_ptr = unsafe { avfilter_get_by_name(CString::new(filter_name).unwrap().as_ptr()) };
         assert!(
             !filter_ptr.is_null(),
-            "avfilter_get_by_name should return a valid pointer for filter '{}'",
-            filter_name
+            "avfilter_get_by_name should return a valid pointer for filter '{filter_name}'"
         );
 
         // Safety: The pointer here is valid.

--- a/crates/ffmpeg/src/frame.rs
+++ b/crates/ffmpeg/src/frame.rs
@@ -730,7 +730,7 @@ mod tests {
         let cloned_frame = frame.clone();
 
         assert_eq!(
-            format!("{:?}", frame),
+            format!("{frame:?}"),
             format!("{:?}", cloned_frame),
             "Cloned frame should be equal to the original frame."
         );
@@ -1001,8 +1001,7 @@ mod tests {
             assert!(
                 // Safety: `frame` is a valid pointer. And we dont attempt to read from the frame until after the allocation.
                 unsafe { frame.alloc_frame_buffer(alignment).is_err() },
-                "Should fail to allocate buffer with invalid frame and alignment {:?}",
-                alignment
+                "Should fail to allocate buffer with invalid frame and alignment {alignment:?}"
             );
         }
     }

--- a/crates/ffmpeg/src/io/input.rs
+++ b/crates/ffmpeg/src/io/input.rs
@@ -209,7 +209,7 @@ mod tests {
         if let Err(err) = result {
             match err {
                 FfmpegError::Code(_) => (),
-                _ => panic!("Unexpected error type: {:?}", err),
+                _ => panic!("Unexpected error type: {err:?}"),
             }
         }
     }
@@ -221,7 +221,7 @@ mod tests {
         let result = Input::new(data);
 
         if let Err(e) = &result {
-            eprintln!("Error encountered: {:?}", e);
+            eprintln!("Error encountered: {e:?}");
         }
 
         assert!(result.is_ok(), "Expected success but got error");
@@ -234,7 +234,7 @@ mod tests {
         let result = Input::seekable(data);
 
         if let Err(e) = &result {
-            eprintln!("Error encountered: {:?}", e);
+            eprintln!("Error encountered: {e:?}");
         }
 
         assert!(result.is_ok(), "Expected success but got error");
@@ -362,7 +362,7 @@ mod tests {
         for _ in 0..5 {
             match packets.next() {
                 Some(Ok(_)) => (),
-                Some(Err(e)) => panic!("Error encountered while reading packets: {:?}", e),
+                Some(Err(e)) => panic!("Error encountered while reading packets: {e:?}"),
                 None => break,
             }
         }

--- a/crates/ffmpeg/src/io/internal.rs
+++ b/crates/ffmpeg/src/io/internal.rs
@@ -407,7 +407,7 @@ mod tests {
                 FfmpegError::Code(_) => {
                     eprintln!("Expected avformat_alloc_output_context2 error occurred.");
                 }
-                _ => panic!("Unexpected error variant: {:?}", error),
+                _ => panic!("Unexpected error variant: {error:?}"),
             }
         }
     }
@@ -438,7 +438,7 @@ mod tests {
         let test_path_str = test_path.to_str().unwrap();
         let result = Inner::open_output(test_path_str);
         if let Err(error) = &result {
-            eprintln!("Function returned an error: {:?}", error);
+            eprintln!("Function returned an error: {error:?}");
         }
 
         assert!(

--- a/crates/ffmpeg/src/log.rs
+++ b/crates/ffmpeg/src/log.rs
@@ -194,10 +194,7 @@ mod tests {
             assert_eq!(
                 log_level.to_string(),
                 expected,
-                "Expected '{}' for input {}, but got '{}'",
-                expected,
-                input,
-                log_level
+                "Expected '{expected}' for input {input}, but got '{log_level}'"
             );
         }
     }
@@ -367,7 +364,7 @@ mod tests {
         ];
 
         for (level, expected_tracing_level) in &levels_and_expected_tracing {
-            let message = format!("Test {} log message", expected_tracing_level);
+            let message = format!("Test {expected_tracing_level} log message");
             // Safety: `av_log` is safe to call.
             unsafe {
                 av_log(
@@ -379,15 +376,11 @@ mod tests {
         }
 
         for (_level, expected_tracing_level) in &levels_and_expected_tracing {
-            let expected_message = format!(
-                "{}: ffmpeg @ Test {} log message",
-                expected_tracing_level, expected_tracing_level
-            );
+            let expected_message = format!("{expected_tracing_level}: ffmpeg @ Test {expected_tracing_level} log message");
 
             assert!(
                 logs_contain(&expected_message),
-                "Expected log message for '{}'",
-                expected_message
+                "Expected log message for '{expected_message}'"
             );
         }
         log_callback_unset();
@@ -419,9 +412,8 @@ mod tests {
         }
 
         assert!(
-            logs_contain(&format!("debug: ffmpeg @ {}", deprecated_message)),
-            "Expected log message for '{}'",
-            deprecated_message
+            logs_contain(&format!("debug: ffmpeg @ {deprecated_message}")),
+            "Expected log message for '{deprecated_message}'"
         );
         log_callback_unset();
     }

--- a/crates/ffmpeg/src/scaler.rs
+++ b/crates/ffmpeg/src/scaler.rs
@@ -203,8 +203,7 @@ mod tests {
 
         assert!(
             result.is_ok(),
-            "Expected Scalar::process to succeed, but got error: {:?}",
-            result
+            "Expected Scalar::process to succeed, but got error: {result:?}"
         );
 
         let output_frame = result.unwrap();

--- a/crates/ffmpeg/src/stream.rs
+++ b/crates/ffmpeg/src/stream.rs
@@ -608,11 +608,11 @@ mod tests {
 
         let serialized_metadata = sorted_metadata
             .iter()
-            .map(|(key, value)| format!("        \"{}\": \"{}\",", key, value))
+            .map(|(key, value)| format!("        \"{key}\": \"{value}\","))
             .collect::<Vec<_>>()
             .join("\n");
 
-        let replacement_metadata = format!("metadata: {{\n{}\n    }}", serialized_metadata);
+        let replacement_metadata = format!("metadata: {{\n{serialized_metadata}\n    }}");
         let mut settings = Settings::new();
         let metadata_regex = r"metadata: \{[^}]*\}";
         settings.add_filter(metadata_regex, &replacement_metadata);

--- a/crates/flv/src/audio/header/legacy.rs
+++ b/crates/flv/src/audio/header/legacy.rs
@@ -170,7 +170,7 @@ mod tests {
         for (value, expected, name) in cases {
             let sound_format = SoundFormat::from(value);
             assert_eq!(sound_format, expected);
-            assert_eq!(format!("{:?}", sound_format), name);
+            assert_eq!(format!("{sound_format:?}"), name);
         }
     }
 
@@ -186,7 +186,7 @@ mod tests {
         for (value, expected, name) in cases {
             let sound_rate = SoundRate::from(value);
             assert_eq!(sound_rate, expected);
-            assert_eq!(format!("{:?}", sound_rate), name);
+            assert_eq!(format!("{sound_rate:?}"), name);
         }
     }
 
@@ -200,7 +200,7 @@ mod tests {
         for (value, expected, name) in cases {
             let sound_size = SoundSize::from(value);
             assert_eq!(sound_size, expected);
-            assert_eq!(format!("{:?}", sound_size), name);
+            assert_eq!(format!("{sound_size:?}"), name);
         }
     }
 
@@ -214,7 +214,7 @@ mod tests {
         for (value, expected, name) in cases {
             let sound_type = SoundType::from(value);
             assert_eq!(sound_type, expected);
-            assert_eq!(format!("{:?}", sound_type), name);
+            assert_eq!(format!("{sound_type:?}"), name);
         }
     }
 }

--- a/crates/flv/src/lib.rs
+++ b/crates/flv/src/lib.rs
@@ -312,7 +312,7 @@ mod tests {
                             assert!(!read_seq_end);
                             read_seq_end = true;
                         }
-                        _ => panic!("expected avc nalu packet: {:?}", data),
+                        _ => panic!("expected avc nalu packet: {data:?}"),
                     }
                 }
                 _ => panic!("unexpected data"),
@@ -522,7 +522,7 @@ mod tests {
                             assert!(!read_seq_end);
                             read_seq_end = true;
                         }
-                        _ => panic!("expected av1 raw packet: {:?}", body),
+                        _ => panic!("expected av1 raw packet: {body:?}"),
                     };
                 }
                 _ => panic!("unexpected data"),
@@ -735,7 +735,7 @@ mod tests {
                             assert!(!read_seq_end);
                             read_seq_end = true;
                         }
-                        _ => panic!("expected hevc nalu packet: {:?}", packet),
+                        _ => panic!("expected hevc nalu packet: {packet:?}"),
                     };
                 }
                 _ => panic!("unexpected data"),

--- a/crates/flv/src/video/body/enhanced/metadata.rs
+++ b/crates/flv/src/video/body/enhanced/metadata.rs
@@ -184,7 +184,7 @@ impl<'de> serde::Deserialize<'de> for VideoPacketMetadataEntry<'de> {
                         key,
                         object: match content.newtype_variant::<Amf0Value>()?.into_owned() {
                             Amf0Value::Object(object) => object,
-                            _ => return Err(A::Error::custom(format!("expected {} object", VIDEO_PACKET_METADATA_ENTRY))),
+                            _ => return Err(A::Error::custom(format!("expected {VIDEO_PACKET_METADATA_ENTRY} object"))),
                         },
                     }),
                 }

--- a/crates/h265/src/tests.rs
+++ b/crates/h265/src/tests.rs
@@ -107,8 +107,7 @@ fn test_parse_sps_with_zero_vui_num_units_in_tick() {
         Err(e) => assert_eq!(
             e.kind(),
             std::io::ErrorKind::InvalidData,
-            "Expected InvalidData error, got {:?}",
-            e
+            "Expected InvalidData error, got {e:?}"
         ),
     }
 }

--- a/crates/http/examples/axum.rs
+++ b/crates/http/examples/axum.rs
@@ -74,7 +74,7 @@ pub fn get_tls_config() -> io::Result<rustls::ServerConfig> {
 // Load public certificate from file.
 fn load_certs(filename: &str) -> io::Result<Vec<CertificateDer<'static>>> {
     // Open certificate file.
-    let certfile = fs::File::open(filename).map_err(|e| io::Error::other(format!("failed to open {}: {}", filename, e)))?;
+    let certfile = fs::File::open(filename).map_err(|e| io::Error::other(format!("failed to open {filename}: {e}")))?;
     let mut reader = io::BufReader::new(certfile);
 
     // Load and return certificate.
@@ -84,10 +84,9 @@ fn load_certs(filename: &str) -> io::Result<Vec<CertificateDer<'static>>> {
 // Load private key from file.
 fn load_private_key(filename: &str) -> io::Result<PrivateKeyDer<'static>> {
     // Open keyfile.
-    let keyfile = fs::File::open(filename).map_err(|e| io::Error::other(format!("failed to open {}: {}", filename, e)))?;
+    let keyfile = fs::File::open(filename).map_err(|e| io::Error::other(format!("failed to open {filename}: {e}")))?;
     let mut reader = io::BufReader::new(keyfile);
 
     // Load and return a single private key.
-    rustls_pemfile::private_key(&mut reader)?
-        .ok_or_else(|| io::Error::other(format!("no private key found in {}", filename)))
+    rustls_pemfile::private_key(&mut reader)?.ok_or_else(|| io::Error::other(format!("no private key found in {filename}")))
 }

--- a/crates/http/examples/echo_tls.rs
+++ b/crates/http/examples/echo_tls.rs
@@ -53,7 +53,7 @@ pub fn get_tls_config() -> io::Result<rustls::ServerConfig> {
 // Load public certificate from file.
 fn load_certs(filename: &str) -> io::Result<Vec<CertificateDer<'static>>> {
     // Open certificate file.
-    let certfile = fs::File::open(filename).map_err(|e| io::Error::other(format!("failed to open {}: {}", filename, e)))?;
+    let certfile = fs::File::open(filename).map_err(|e| io::Error::other(format!("failed to open {filename}: {e}")))?;
     let mut reader = io::BufReader::new(certfile);
 
     // Load and return certificate.
@@ -63,10 +63,9 @@ fn load_certs(filename: &str) -> io::Result<Vec<CertificateDer<'static>>> {
 // Load private key from file.
 fn load_private_key(filename: &str) -> io::Result<PrivateKeyDer<'static>> {
     // Open keyfile.
-    let keyfile = fs::File::open(filename).map_err(|e| io::Error::other(format!("failed to open {}: {}", filename, e)))?;
+    let keyfile = fs::File::open(filename).map_err(|e| io::Error::other(format!("failed to open {filename}: {e}")))?;
     let mut reader = io::BufReader::new(keyfile);
 
     // Load and return a single private key.
-    rustls_pemfile::private_key(&mut reader)?
-        .ok_or_else(|| io::Error::other(format!("no private key found in {}", filename)))
+    rustls_pemfile::private_key(&mut reader)?.ok_or_else(|| io::Error::other(format!("no private key found in {filename}")))
 }

--- a/crates/http/src/body.rs
+++ b/crates/http/src/body.rs
@@ -220,6 +220,6 @@ mod tests {
         }
 
         let err = TrackedBodyError::<TestBody, TestTracker>::Body(());
-        assert_eq!(format!("{:?}", err), "TrackedBodyError::Body(())",);
+        assert_eq!(format!("{err:?}"), "TrackedBodyError::Body(())",);
     }
 }

--- a/crates/http/src/lib.rs
+++ b/crates/http/src/lib.rs
@@ -133,7 +133,7 @@ mod tests {
         // Wait for the server to start
         tokio::time::sleep(std::time::Duration::from_millis(100)).await;
 
-        let url = format!("http://{}/", addr);
+        let url = format!("http://{addr}/");
 
         for version in versions {
             let mut builder = reqwest::Client::builder().danger_accept_invalid_certs(true);
@@ -198,7 +198,7 @@ mod tests {
         // Wait for the server to start
         tokio::time::sleep(std::time::Duration::from_millis(100)).await;
 
-        let url = format!("https://{}/", addr);
+        let url = format!("https://{addr}/");
 
         for version in versions {
             let mut builder = reqwest::Client::builder().danger_accept_invalid_certs(true).https_only(true);
@@ -223,7 +223,7 @@ mod tests {
             let resp = client
                 .execute(request)
                 .await
-                .unwrap_or_else(|_| panic!("failed to get response version {:?}", version))
+                .unwrap_or_else(|_| panic!("failed to get response version {version:?}"))
                 .text()
                 .await
                 .expect("failed to get text");

--- a/crates/http/src/service/function.rs
+++ b/crates/http/src/service/function.rs
@@ -105,7 +105,7 @@ mod tests {
     fn fn_service_debug() {
         let service = super::fn_http_service(|_| async { Ok::<_, Infallible>(http::Response::new(String::new())) });
         assert_eq!(
-            format!("{:?}", service),
+            format!("{service:?}"),
             "FnHttpService(\"scuffle_http::service::function::tests::fn_service_debug::{{closure}}\")"
         );
     }
@@ -118,7 +118,7 @@ mod tests {
             }))
         });
         assert_eq!(
-            format!("{:?}", factory),
+            format!("{factory:?}"),
             "FnHttpServiceFactory(\"scuffle_http::service::function::tests::fn_service_factory_debug::{{closure}}\")"
         );
     }

--- a/crates/metrics/examples/prometheus.rs
+++ b/crates/metrics/examples/prometheus.rs
@@ -50,5 +50,5 @@ async fn main() {
 
     prometheus_client::encoding::text::encode(&mut buffer, &registry).unwrap();
 
-    println!("{}", buffer);
+    println!("{buffer}");
 }

--- a/crates/metrics/src/prometheus/mod.rs
+++ b/crates/metrics/src/prometheus/mod.rs
@@ -425,13 +425,13 @@ impl prometheus_client::encoding::EncodeLabelSet for KeyValueEncoder<'_> {
             if prometheus_full_utf8 {
                 // TODO(troy): I am not sure if this is correct.
                 // See: https://github.com/prometheus/client_rust/issues/251
-                write!(&mut key_encoder, "{}", key)?;
+                write!(&mut key_encoder, "{key}")?;
             } else {
                 write!(&mut key_encoder, "{}", escape_key(key))?;
             }
 
             let mut value_encoder = key_encoder.encode_label_value()?;
-            write!(&mut value_encoder, "{}", value)?;
+            write!(&mut value_encoder, "{value}")?;
 
             value_encoder.finish()
         }

--- a/crates/mp4/src/codec.rs
+++ b/crates/mp4/src/codec.rs
@@ -40,7 +40,7 @@ impl fmt::Display for VideoCodec {
                 profile,
                 constraint_set,
                 level,
-            } => write!(f, "avc1.{:02x}{:02x}{:02x}", profile, constraint_set, level),
+            } => write!(f, "avc1.{profile:02x}{constraint_set:02x}{level:02x}"),
             VideoCodec::Hevc {
                 general_profile_space,
                 profile,
@@ -238,7 +238,7 @@ impl FromStr for VideoCodec {
                     full_range_flag,
                 })
             }
-            r => Err(format!("invalid codec, unknown type: {}", r)),
+            r => Err(format!("invalid codec, unknown type: {r}")),
         }
     }
 }
@@ -282,7 +282,7 @@ impl FromStr for AudioCodec {
                 })
             }
             "opus" => Ok(AudioCodec::Opus),
-            r => Err(format!("invalid codec, unknown type: {}", r)),
+            r => Err(format!("invalid codec, unknown type: {r}")),
         }
     }
 }

--- a/crates/postcompile/src/deps.rs
+++ b/crates/postcompile/src/deps.rs
@@ -195,7 +195,7 @@ impl Dependencies {
 
         let output = match metadata.output() {
             Err(e) => {
-                eprintln!("failed to run cargo metadata: \n{:#}", e);
+                eprintln!("failed to run cargo metadata: \n{e:#}");
                 std::process::exit(1);
             }
             Ok(output) => output,

--- a/crates/postcompile/src/lib.rs
+++ b/crates/postcompile/src/lib.rs
@@ -113,7 +113,7 @@ impl std::fmt::Display for ExitStatus {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         match self {
             ExitStatus::Success => write!(f, "0"),
-            ExitStatus::Failure(code) => write!(f, "{}", code),
+            ExitStatus::Failure(code) => write!(f, "{code}"),
         }
     }
 }

--- a/crates/rtmp/src/chunk/reader.rs
+++ b/crates/rtmp/src/chunk/reader.rs
@@ -569,16 +569,16 @@ mod tests {
     #[test]
     fn test_reader_error_display() {
         let error = ChunkReadError::MissingPreviousChunkHeader(123);
-        assert_eq!(format!("{}", error), "missing previous chunk header: 123");
+        assert_eq!(format!("{error}"), "missing previous chunk header: 123");
 
         let error = ChunkReadError::TooManyPartialChunks;
-        assert_eq!(format!("{}", error), "too many partial chunks");
+        assert_eq!(format!("{error}"), "too many partial chunks");
 
         let error = ChunkReadError::TooManyPreviousChunkHeaders;
-        assert_eq!(format!("{}", error), "too many previous chunk headers");
+        assert_eq!(format!("{error}"), "too many previous chunk headers");
 
         let error = ChunkReadError::PartialChunkTooLarge(100);
-        assert_eq!(format!("{}", error), "partial chunk too large: 100");
+        assert_eq!(format!("{error}"), "partial chunk too large: 100");
     }
 
     #[test]
@@ -916,7 +916,7 @@ mod tests {
         let err = unpacker.read_chunk(&mut buf).unwrap_err();
         match err {
             crate::error::RtmpError::ChunkRead(ChunkReadError::MissingPreviousChunkHeader(3)) => {}
-            _ => panic!("Unexpected error: {:?}", err),
+            _ => panic!("Unexpected error: {err:?}"),
         }
     }
 
@@ -940,7 +940,7 @@ mod tests {
         let err = unpacker.read_chunk(&mut buf).unwrap_err();
         match err {
             crate::error::RtmpError::ChunkRead(ChunkReadError::PartialChunkTooLarge(16777215)) => {}
-            _ => panic!("Unexpected error: {:?}", err),
+            _ => panic!("Unexpected error: {err:?}"),
         }
     }
 
@@ -970,7 +970,7 @@ mod tests {
             assert!(
                 unpacker
                     .read_chunk(&mut buf)
-                    .unwrap_or_else(|_| panic!("chunk failed {}", i))
+                    .unwrap_or_else(|_| panic!("chunk failed {i}"))
                     .is_none()
             );
         }
@@ -993,7 +993,7 @@ mod tests {
         let err = unpacker.read_chunk(&mut buf).unwrap_err();
         match err {
             crate::error::RtmpError::ChunkRead(ChunkReadError::TooManyPartialChunks) => {}
-            _ => panic!("Unexpected error: {:?}", err),
+            _ => panic!("Unexpected error: {err:?}"),
         }
     }
 
@@ -1020,7 +1020,7 @@ mod tests {
             assert!(
                 unpacker
                     .read_chunk(&mut buf)
-                    .unwrap_or_else(|_| panic!("chunk failed {}", i))
+                    .unwrap_or_else(|_| panic!("chunk failed {i}"))
                     .is_some()
             );
         }
@@ -1039,7 +1039,7 @@ mod tests {
         let err = unpacker.read_chunk(&mut buf).unwrap_err();
         match err {
             crate::error::RtmpError::ChunkRead(ChunkReadError::TooManyPreviousChunkHeaders) => {}
-            _ => panic!("Unexpected error: {:?}", err),
+            _ => panic!("Unexpected error: {err:?}"),
         }
     }
 

--- a/crates/rtmp/src/command_messages/writer.rs
+++ b/crates/rtmp/src/command_messages/writer.rs
@@ -29,7 +29,7 @@ impl Display for CommandResultLevel {
             CommandResultLevel::Warning => write!(f, "warning"),
             CommandResultLevel::Status => write!(f, "status"),
             CommandResultLevel::Error => write!(f, "error"),
-            CommandResultLevel::Unknown(s) => write!(f, "{}", s),
+            CommandResultLevel::Unknown(s) => write!(f, "{s}"),
         }
     }
 }

--- a/crates/rtmp/src/lib.rs
+++ b/crates/rtmp/src/lib.rs
@@ -197,7 +197,7 @@ mod tests {
             (
                 tokio::spawn(async move {
                     let r = session.run().await;
-                    println!("ffmpeg session ended: {:?}", r);
+                    println!("ffmpeg session ended: {r:?}");
                     r
                 }),
                 ffmpeg_event_reciever,
@@ -331,7 +331,7 @@ mod tests {
             (
                 tokio::spawn(async move {
                     let r = session.run().await;
-                    println!("ffmpeg session ended: {:?}", r);
+                    println!("ffmpeg session ended: {r:?}");
                     r
                 }),
                 ffmpeg_event_reciever,

--- a/crates/settings/examples/cli.rs
+++ b/crates/settings/examples/cli.rs
@@ -14,5 +14,5 @@ fn main() {
         env_prefix: Some("APP"),
     });
 
-    println!("{:#?}", config);
+    println!("{config:#?}");
 }

--- a/crates/settings/src/lib.rs
+++ b/crates/settings/src/lib.rs
@@ -207,7 +207,7 @@ impl config::Format for FormatWrapper {
 
         Err(Box::new(std::io::Error::new(
             std::io::ErrorKind::InvalidData,
-            format!("No supported format found for file: {:?}", uri),
+            format!("No supported format found for file: {uri:?}"),
         )))
     }
 }
@@ -407,7 +407,7 @@ mod tests {
         if let crate::SettingsError::Clap(err) = err {
             assert_eq!(err.to_string(), "error: Override must be in the format KEY=VALUE");
         } else {
-            panic!("unexpected error: {}", err);
+            panic!("unexpected error: {err}");
         }
     }
 
@@ -457,7 +457,7 @@ mod tests {
                 format!("No supported format found for file: {:?}", path.to_str())
             );
         } else {
-            panic!("unexpected error: {:?}", err);
+            panic!("unexpected error: {err:?}");
         }
     }
 

--- a/crates/signal/src/bootstrap.rs
+++ b/crates/signal/src/bootstrap.rs
@@ -123,7 +123,7 @@ mod test {
             Ok(Ok(Err(e))) => {
                 assert_eq!(e.to_string(), "received signal, shutting down immediately: Interrupt");
             }
-            r => panic!("unexpected result: {:?}", r),
+            r => panic!("unexpected result: {r:?}"),
         }
 
         assert!(

--- a/crates/transmuxer/src/tests/mod.rs
+++ b/crates/transmuxer/src/tests/mod.rs
@@ -96,7 +96,7 @@ fn test_transmuxer_avc_aac() {
 
     let output = String::from_utf8(output.stdout).unwrap();
 
-    println!("{}", output);
+    println!("{output}");
 
     // Check the output is valid.
     let json: serde_json::Value = serde_json::from_str(&output).unwrap();

--- a/dev-tools/xtask/src/cmd/change_logs/check_pr.rs
+++ b/dev-tools/xtask/src/cmd/change_logs/check_pr.rs
@@ -28,7 +28,7 @@ impl CheckPr {
             .join("changes.d")
             .join(format!("pr-{}.toml", self.pr_number));
 
-        eprintln!("checking {}", path);
+        eprintln!("checking {path}");
 
         if !self.required && !path.exists() {
             return Ok(());

--- a/dev-tools/xtask/src/cmd/change_logs/generate.rs
+++ b/dev-tools/xtask/src/cmd/change_logs/generate.rs
@@ -132,7 +132,7 @@ impl Generate {
 
         let path = metadata.workspace_root.join("changes.d");
 
-        eprintln!("reading {}", path);
+        eprintln!("reading {path}");
 
         let mut change_fragments = std::fs::read_dir(&path)?
             .filter_map(|entry| entry.ok())

--- a/dev-tools/xtask/src/cmd/power_set/mod.rs
+++ b/dev-tools/xtask/src/cmd/power_set/mod.rs
@@ -147,7 +147,7 @@ impl PowerSet {
 
                 cmd.args(&self.args);
 
-                println!("executing {:?} ({}/{})", cmd, i, total);
+                println!("executing {cmd:?} ({i}/{total})");
 
                 if !cmd.status()?.success() {
                     failed.push((*package, features));
@@ -168,7 +168,7 @@ impl PowerSet {
         if !failed.is_empty() {
             eprintln!("failed to execute command for the following:");
             for (package, features) in failed {
-                eprintln!("  {} with features {:?}", package, features);
+                eprintln!("  {package} with features {features:?}");
             }
 
             anyhow::bail!("failed to execute command for some packages after {:?}", start.elapsed());

--- a/dev-tools/xtask/src/cmd/semver_checks/mod.rs
+++ b/dev-tools/xtask/src/cmd/semver_checks/mod.rs
@@ -52,7 +52,7 @@ impl SemverChecks {
         // need to print an empty line for the bullet list to format correctly
         println!();
         for krate in crates {
-            println!("- `{}`", krate);
+            println!("- `{krate}`");
         }
         // close crate details
         println!("</details>");

--- a/dev-tools/xtask/src/cmd/semver_checks/utils.rs
+++ b/dev-tools/xtask/src/cmd/semver_checks/utils.rs
@@ -23,10 +23,10 @@ impl Drop for WorktreeCleanup {
                 println!("Successfully removed git worktree");
             }
             Ok(status) => {
-                eprintln!("Failed to remove git worktree. Exit code: {}", status);
+                eprintln!("Failed to remove git worktree. Exit code: {status}");
             }
             Err(e) => {
-                eprintln!("Error removing git worktree: {:?}", e);
+                eprintln!("Error removing git worktree: {e:?}");
             }
         }
 
@@ -55,10 +55,7 @@ pub fn checkout_baseline(baseline_rev_or_hash: &str, target_dir: &PathBuf) -> Re
     let commit_hash = if rev_parse_output.status.success() {
         String::from_utf8(rev_parse_output.stdout)?.trim().to_string()
     } else {
-        println!(
-            "Revision {} not found locally. Fetching from origin...\n",
-            baseline_rev_or_hash
-        );
+        println!("Revision {baseline_rev_or_hash} not found locally. Fetching from origin...\n");
 
         Command::new("git")
             .args(["fetch", "--depth", "1", "origin", baseline_rev_or_hash])
@@ -78,10 +75,10 @@ pub fn checkout_baseline(baseline_rev_or_hash: &str, target_dir: &PathBuf) -> Re
             .status
             .success()
             .then(|| String::from_utf8(retry_output.stdout).unwrap().trim().to_string())
-            .context(format!("Failed to resolve revision {}", baseline_rev_or_hash))?
+            .context(format!("Failed to resolve revision {baseline_rev_or_hash}"))?
     };
 
-    println!("Checking out commit {} into {:?}\n", commit_hash, target_dir);
+    println!("Checking out commit {commit_hash} into {target_dir:?}\n");
 
     Command::new("git")
         .args(["worktree", "add", "--detach", target_dir.to_str().unwrap(), &commit_hash])


### PR DESCRIPTION
This fixes a newly added clippy lint [`uninlined-format-args`](https://rust-lang.github.io/rust-clippy/master/index.html#uninlined_format_args).