### PR TITLE
minor ci fixes

### DIFF
--- a/.github/labels.yaml
+++ b/.github/labels.yaml
@@ -34,3 +34,5 @@
   color: "32a852"
 - name: "automated"
   color: "a62b33"
+- name: "do-not-merge"
+  color: "7d1700"

--- a/.github/workflows/cargo-update.yaml
+++ b/.github/workflows/cargo-update.yaml
@@ -1,4 +1,4 @@
-name: Cargo Update
+name: Cargo Update PR
 
 on:
   workflow_dispatch:
@@ -10,11 +10,12 @@ env:
 
 jobs:
   cargo-update:
-    name: Cargo Update
+    name: Cargo Update PR
     runs-on: ubuntu-24.04
     permissions:
       contents: write
       pull-requests: write
+      issues: write
     steps:
       - name: Checkout repository
         uses: actions/checkout@v4

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -15,7 +15,7 @@ jobs:
   crates-io:
     name: Crates.io
     runs-on: ubicloud-standard-8
-    environment: crates
+    environment: crates.io
     permissions:
       contents: write
     steps:


### PR DESCRIPTION
Some minor ci fixes

- fixed deploy env name on crates release to be where the crates are published to (crates.io)
- added a new label to be `do-not-merge` when a PR should not be merged.
- fix cargo update pr labels permission
