### PR TITLE
Use serde_derive directly instead of serde's derive feature

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2115,6 +2115,7 @@ dependencies = [
  "prettyplease",
  "scuffle-workspace-hack",
  "serde",
+ "serde_derive",
  "serde_json",
  "syn",
  "target-triple",
@@ -2717,6 +2718,7 @@ dependencies = [
  "scuffle-bytes-util",
  "scuffle-workspace-hack",
  "serde",
+ "serde_derive",
  "thiserror 2.0.12",
 ]
 
@@ -2759,6 +2761,7 @@ dependencies = [
  "scuffle-signal",
  "scuffle-workspace-hack",
  "serde",
+ "serde_derive",
  "smart-default",
  "tokio",
  "tracing",
@@ -2882,6 +2885,7 @@ dependencies = [
  "scuffle-h265",
  "scuffle-workspace-hack",
  "serde",
+ "serde_derive",
  "thiserror 2.0.12",
 ]
 
@@ -3029,6 +3033,7 @@ dependencies = [
  "scuffle-future-ext",
  "scuffle-workspace-hack",
  "serde",
+ "serde_derive",
  "serde_json",
  "sha2",
  "thiserror 2.0.12",
@@ -3048,6 +3053,7 @@ dependencies = [
  "scuffle-bootstrap",
  "scuffle-workspace-hack",
  "serde",
+ "serde_derive",
  "smart-default",
  "thiserror 2.0.12",
 ]
@@ -4382,6 +4388,7 @@ dependencies = [
  "regex",
  "semver",
  "serde",
+ "serde_derive",
  "serde_json",
  "toml_edit",
 ]

--- a/changes.d/pr-440.toml
+++ b/changes.d/pr-440.toml
@@ -1,0 +1,29 @@
+[[scuffle-amf0]]
+category = "chore"
+description = "Use serde_derive instead of serde's derive feature for improved compile times"
+authors = ["@philipch07"]
+
+[[scuffle-bootstrap]]
+category = "chore"
+description = "Use serde_derive instead of serde's derive feature for improved compile times"
+authors = ["@philipch07"]
+
+[[scuffle-flv]]
+category = "chore"
+description = "Use serde_derive instead of serde's derive feature for improved compile times"
+authors = ["@philipch07"]
+
+[[postcompile]]
+category = "chore"
+description = "Use serde_derive instead of serde's derive feature for improved compile times"
+authors = ["@philipch07"]
+
+[[scuffle-rtmp]]
+category = "chore"
+description = "Use serde_derive instead of serde's derive feature for improved compile times"
+authors = ["@philipch07"]
+
+[[scuffle-settings]]
+category = "chore"
+description = "Use serde_derive instead of serde's derive feature for improved compile times"
+authors = ["@philipch07"]

--- a/crates/amf0/Cargo.toml
+++ b/crates/amf0/Cargo.toml
@@ -11,7 +11,7 @@ keywords = ["amf0", "rtmp", "flash", "video", "flv"]
 unexpected_cfgs = { level = "warn", check-cfg = ['cfg(coverage_nightly)'] }
 
 [dependencies]
-serde = { version = "1.0.219", optional = true }
+serde = { version = "1", optional = true }
 bytes = "1.10.1"
 byteorder = "1.5"
 num-traits = "0.2"
@@ -22,7 +22,7 @@ scuffle-bytes-util = { workspace = true }
 scuffle-workspace-hack.workspace = true
 
 [dev-dependencies]
-serde_derive = "1.0.219"
+serde_derive = "1"
 
 [features]
 serde = ["dep:serde", "scuffle-bytes-util/serde"]

--- a/crates/amf0/Cargo.toml
+++ b/crates/amf0/Cargo.toml
@@ -22,7 +22,7 @@ scuffle-bytes-util = { workspace = true }
 scuffle-workspace-hack.workspace = true
 
 [dev-dependencies]
-serde = { version = "1.0.219", features = ["derive"] }
+serde_derive = "1.0.219"
 
 [features]
 serde = ["dep:serde", "scuffle-bytes-util/serde"]

--- a/crates/amf0/src/de/mod.rs
+++ b/crates/amf0/src/de/mod.rs
@@ -484,6 +484,7 @@ mod tests {
 
     use bytes::Bytes;
     use scuffle_bytes_util::StringCow;
+    use serde_derive::Deserialize;
 
     use crate::de::MultiValue;
     use crate::decoder::Amf0Decoder;
@@ -625,7 +626,7 @@ mod tests {
         let value: Option<bool> = from_buf(Bytes::from_owner(bytes)).unwrap();
         assert_eq!(value, Some(false));
 
-        #[derive(serde::Deserialize, PartialEq, Debug)]
+        #[derive(Deserialize, PartialEq, Debug)]
         struct Unit;
 
         let bytes = [Amf0Marker::Null as u8];
@@ -635,7 +636,7 @@ mod tests {
 
     #[test]
     fn newtype_struct() {
-        #[derive(serde::Deserialize, Debug, PartialEq)]
+        #[derive(Deserialize, Debug, PartialEq)]
         struct Test(String);
 
         #[rustfmt::skip]
@@ -650,7 +651,7 @@ mod tests {
 
     #[test]
     fn tuple_struct() {
-        #[derive(serde::Deserialize, Debug, PartialEq)]
+        #[derive(Deserialize, Debug, PartialEq)]
         struct Test(bool, String);
 
         #[rustfmt::skip]
@@ -679,7 +680,7 @@ mod tests {
 
     #[test]
     fn typed_object() {
-        #[derive(serde::Deserialize, Debug, PartialEq)]
+        #[derive(Deserialize, Debug, PartialEq)]
         struct Test {
             a: bool,
             b: String,
@@ -713,7 +714,7 @@ mod tests {
 
     #[test]
     fn simple_struct() {
-        #[derive(serde::Deserialize, Debug, PartialEq)]
+        #[derive(Deserialize, Debug, PartialEq)]
         struct Test {
             a: bool,
             b: String,
@@ -791,7 +792,7 @@ mod tests {
 
     #[test]
     fn simple_enum() {
-        #[derive(serde::Deserialize, Debug, PartialEq)]
+        #[derive(Deserialize, Debug, PartialEq)]
         enum Test {
             A,
             B,
@@ -818,7 +819,7 @@ mod tests {
 
     #[test]
     fn complex_enum() {
-        #[derive(serde::Deserialize, Debug, PartialEq)]
+        #[derive(Deserialize, Debug, PartialEq)]
         enum Test {
             A(bool),
             B { a: String, b: String },
@@ -924,7 +925,7 @@ mod tests {
             0, 0, Amf0Marker::ObjectEnd as u8,
         ];
 
-        #[derive(serde::Deserialize, Debug, PartialEq)]
+        #[derive(Deserialize, Debug, PartialEq)]
         struct Test<'a> {
             b: String,
             #[serde(flatten, borrow)]

--- a/crates/amf0/src/ser.rs
+++ b/crates/amf0/src/ser.rs
@@ -549,6 +549,8 @@ mod tests {
     use std::collections::HashMap;
     use std::hash::Hash;
 
+    use serde_derive::Serialize;
+
     use crate::{Amf0Error, Amf0Marker, Amf0Value, to_bytes};
 
     #[test]
@@ -603,7 +605,7 @@ mod tests {
         let bytes = to_bytes(&None::<String>).unwrap();
         assert_eq!(bytes, [Amf0Marker::Null as u8]);
 
-        #[derive(serde::Serialize)]
+        #[derive(Serialize)]
         struct Unit;
         let bytes = to_bytes(&Unit).unwrap();
         assert_eq!(bytes, [Amf0Marker::Null as u8]);
@@ -614,7 +616,7 @@ mod tests {
 
     #[test]
     fn tuple_struct() {
-        #[derive(serde::Serialize)]
+        #[derive(Serialize)]
         struct TupleStruct(String, String);
 
         let value = TupleStruct("hello".to_string(), "world".to_string());
@@ -638,7 +640,7 @@ mod tests {
 
     #[test]
     fn newtype_struct() {
-        #[derive(serde::Serialize)]
+        #[derive(Serialize)]
         struct NewtypeStruct(String);
 
         let value = NewtypeStruct("hello".to_string());
@@ -732,7 +734,7 @@ mod tests {
 
     #[test]
     fn simple_struct() {
-        #[derive(serde::Serialize)]
+        #[derive(Serialize)]
         struct Test {
             a: f64,
             b: String,
@@ -767,7 +769,7 @@ mod tests {
 
     #[test]
     fn simple_enum() {
-        #[derive(serde::Serialize)]
+        #[derive(Serialize)]
         enum Test {
             A,
             B,
@@ -798,7 +800,7 @@ mod tests {
 
     #[test]
     fn complex_enum() {
-        #[derive(serde::Serialize)]
+        #[derive(Serialize)]
         enum Test {
             A(bool),
             B { a: String, b: String },
@@ -895,25 +897,25 @@ mod tests {
         test_invalid_map_key(vec![1, 2, 3]);
         test_invalid_map_key((1, 2, 3));
 
-        #[derive(serde::Serialize, Eq, PartialEq, Hash)]
+        #[derive(Serialize, Eq, PartialEq, Hash)]
         struct Tuple(String, String);
         test_invalid_map_key(Tuple("hello".to_string(), "world".to_string()));
 
-        #[derive(serde::Serialize, Eq, PartialEq, Hash)]
+        #[derive(Serialize, Eq, PartialEq, Hash)]
         struct Struct {
             a: String,
         }
         test_invalid_map_key(Struct { a: "hello".to_string() });
 
-        #[derive(serde::Serialize, Eq, PartialEq, Hash)]
+        #[derive(Serialize, Eq, PartialEq, Hash)]
         struct Unit;
         test_invalid_map_key(Unit);
 
-        #[derive(serde::Serialize, Eq, PartialEq, Hash)]
+        #[derive(Serialize, Eq, PartialEq, Hash)]
         struct Newtype(String);
         test_invalid_map_key(Newtype("hello".to_string()));
 
-        #[derive(serde::Serialize, Eq, PartialEq, Hash)]
+        #[derive(Serialize, Eq, PartialEq, Hash)]
         enum Enum {
             A,
             B(bool),

--- a/crates/bootstrap/Cargo.toml
+++ b/crates/bootstrap/Cargo.toml
@@ -42,8 +42,8 @@ scuffle-future-ext.workspace = true
 scuffle-signal = { workspace = true, features = ["bootstrap"] }
 
 # For examples:
-serde = "1.0.219"
-serde_derive = "1.0.219"
+serde = "1"
+serde_derive = "1"
 smart-default = "0.7"
 tracing = "0.1"
 tracing-subscriber = "0.3"

--- a/crates/bootstrap/Cargo.toml
+++ b/crates/bootstrap/Cargo.toml
@@ -42,7 +42,8 @@ scuffle-future-ext.workspace = true
 scuffle-signal = { workspace = true, features = ["bootstrap"] }
 
 # For examples:
-serde = { version = "1", features = ["derive"] }
+serde = "1.0.219"
+serde_derive = "1.0.219"
 smart-default = "0.7"
 tracing = "0.1"
 tracing-subscriber = "0.3"

--- a/crates/bootstrap/examples/cli.rs
+++ b/crates/bootstrap/examples/cli.rs
@@ -3,6 +3,7 @@ use std::sync::Arc;
 use scuffle_bootstrap::prelude::*;
 use scuffle_bootstrap::service::Service;
 use scuffle_signal::{SignalConfig, SignalSvc};
+use serde_derive::Deserialize;
 
 scuffle_bootstrap::main! {
     Global {
@@ -45,7 +46,7 @@ struct Global {
     pub config: Config,
 }
 
-#[derive(serde::Deserialize, Debug, smart_default::SmartDefault)]
+#[derive(Deserialize, Debug, smart_default::SmartDefault)]
 #[serde(default)]
 struct Config {
     #[default = "foo"]

--- a/crates/flv/Cargo.toml
+++ b/crates/flv/Cargo.toml
@@ -14,7 +14,8 @@ keywords = ["flv", "demuxer"]
 unexpected_cfgs = { level = "warn", check-cfg = ['cfg(coverage_nightly)'] }
 
 [dependencies]
-serde = { version = "1.0.219", features = ["derive"] }
+serde = "1.0.219"
+serde_derive = "1.0.219"
 byteorder = "1.5"
 bytes = "1.5"
 num-traits = "0.2"

--- a/crates/flv/Cargo.toml
+++ b/crates/flv/Cargo.toml
@@ -14,8 +14,8 @@ keywords = ["flv", "demuxer"]
 unexpected_cfgs = { level = "warn", check-cfg = ['cfg(coverage_nightly)'] }
 
 [dependencies]
-serde = "1.0.219"
-serde_derive = "1.0.219"
+serde = "1"
+serde_derive = "1"
 byteorder = "1.5"
 bytes = "1.5"
 num-traits = "0.2"

--- a/crates/flv/src/script.rs
+++ b/crates/flv/src/script.rs
@@ -9,6 +9,7 @@ use scuffle_amf0::decoder::Amf0Decoder;
 use scuffle_amf0::{Amf0Object, Amf0Value};
 use scuffle_bytes_util::{BytesCursorExt, StringCow};
 use serde::de::VariantAccess;
+use serde_derive::Deserialize;
 
 use crate::audio::header::enhanced::AudioFourCc;
 use crate::audio::header::legacy::SoundFormat;
@@ -83,7 +84,7 @@ impl<'de> serde::Deserialize<'de> for OnMetaDataVideoCodecId {
 /// Defined by:
 /// - Legacy FLV spec, Annex E.5
 /// - Enhanced RTMP spec, page 13-16, Enhancing onMetaData
-#[derive(Debug, Clone, PartialEq, serde::Deserialize)]
+#[derive(Debug, Clone, PartialEq, Deserialize)]
 #[serde(rename_all = "camelCase", bound = "'a: 'de")]
 pub struct OnMetaData<'a> {
     /// Audio codec ID used in the file.
@@ -176,7 +177,7 @@ pub struct OnMetaData<'a> {
 ///
 /// Defined by:
 /// - Legacy FLV spec, Annex E.6
-#[derive(Debug, Clone, PartialEq, serde::Deserialize)]
+#[derive(Debug, Clone, PartialEq, Deserialize)]
 #[serde(rename_all = "camelCase", bound = "'a: 'de")]
 pub struct OnXmpData<'a> {
     /// XMP metadata, formatted according to the XMP metadata specification.

--- a/crates/flv/src/video/body/enhanced/metadata.rs
+++ b/crates/flv/src/video/body/enhanced/metadata.rs
@@ -5,6 +5,7 @@ use core::fmt;
 use scuffle_amf0::{Amf0Object, Amf0Value};
 use scuffle_bytes_util::StringCow;
 use serde::de::{Error, VariantAccess};
+use serde_derive::Deserialize;
 
 /// Color configuration metadata.
 ///
@@ -13,7 +14,7 @@ use serde::de::{Error, VariantAccess};
 /// > respective tables which are described in "Colour primaries",
 /// > "Transfer characteristics" and "Matrix coefficients" sections.
 /// > It is RECOMMENDED to provide these values.
-#[derive(Debug, Clone, PartialEq, serde::Deserialize)]
+#[derive(Debug, Clone, PartialEq, Deserialize)]
 #[serde(rename_all = "camelCase")]
 pub struct MetadataColorInfoColorConfig {
     /// Number of bits used to record the color channels for each pixel.
@@ -39,7 +40,7 @@ pub struct MetadataColorInfoColorConfig {
 }
 
 /// HDR content light level metadata.
-#[derive(Debug, Clone, PartialEq, serde::Deserialize)]
+#[derive(Debug, Clone, PartialEq, Deserialize)]
 #[serde(rename_all = "camelCase")]
 pub struct MetadataColorInfoHdrCll {
     /// Maximum value of the frame average light level
@@ -73,7 +74,7 @@ pub struct MetadataColorInfoHdrCll {
 /// > Values SHALL be specified with four decimal places. The x coordinate SHALL
 /// > be in the range [0.0001, 0.7400]. The y coordinate SHALL be
 /// > in the range [0.0001, 0.8400].
-#[derive(Debug, Clone, PartialEq, serde::Deserialize)]
+#[derive(Debug, Clone, PartialEq, Deserialize)]
 #[serde(rename_all = "camelCase")]
 pub struct MetadataColorInfoHdrMdcv {
     /// Red x coordinate.
@@ -126,7 +127,7 @@ pub struct MetadataColorInfoHdrMdcv {
 ///
 /// Defined by:
 /// - Enhanced RTMP spec, page 32-34, Metadata Frame
-#[derive(Debug, Clone, PartialEq, serde::Deserialize)]
+#[derive(Debug, Clone, PartialEq, Deserialize)]
 #[serde(rename_all = "camelCase")]
 pub struct MetadataColorInfo {
     /// Color configuration metadata.

--- a/crates/postcompile/Cargo.toml
+++ b/crates/postcompile/Cargo.toml
@@ -19,7 +19,8 @@ serde_json = "1.0"
 cargo_metadata = "0.19.1"
 cargo-platform = "0.1"
 target-triple = "0.1"
-serde = { version = "1.0", features = ["derive"] }
+serde = "1.0.219"
+serde_derive = "1.0.219"
 prettyplease = { version = "0.2", optional = true }
 syn = { version = "2", features = ["full"] }
 scuffle-workspace-hack.workspace = true

--- a/crates/postcompile/Cargo.toml
+++ b/crates/postcompile/Cargo.toml
@@ -19,8 +19,8 @@ serde_json = "1.0"
 cargo_metadata = "0.19.1"
 cargo-platform = "0.1"
 target-triple = "0.1"
-serde = "1.0.219"
-serde_derive = "1.0.219"
+serde = "1"
+serde_derive = "1"
 prettyplease = { version = "0.2", optional = true }
 syn = { version = "2", features = ["full"] }
 scuffle-workspace-hack.workspace = true

--- a/crates/postcompile/src/features.rs
+++ b/crates/postcompile/src/features.rs
@@ -4,6 +4,7 @@ use std::path::PathBuf;
 use std::{env, fs};
 
 use serde::de::{self, Deserialize, DeserializeOwned, Deserializer};
+use serde_derive::Deserialize;
 
 pub(crate) fn find() -> Option<Vec<String>> {
     try_find().ok()
@@ -17,7 +18,7 @@ impl<E: Error> From<E> for Ignored {
     }
 }
 
-#[derive(serde::Deserialize)]
+#[derive(Deserialize)]
 struct Build {
     #[serde(deserialize_with = "from_json")]
     features: Vec<String>,

--- a/crates/rtmp/Cargo.toml
+++ b/crates/rtmp/Cargo.toml
@@ -19,8 +19,8 @@ path = "examples/basic.rs"
 
 [dependencies]
 tokio = { version = "1.36", features = ["io-util", "sync"] }
-serde = "1.0.219"
-serde_derive = "1.0.219"
+serde = "1"
+serde_derive = "1"
 byteorder = "1.5"
 bytes = "1.5"
 tracing = "0.1"

--- a/crates/rtmp/Cargo.toml
+++ b/crates/rtmp/Cargo.toml
@@ -19,7 +19,8 @@ path = "examples/basic.rs"
 
 [dependencies]
 tokio = { version = "1.36", features = ["io-util", "sync"] }
-serde = { version = "1.0.219", features = ["derive"] }
+serde = "1.0.219"
+serde_derive = "1.0.219"
 byteorder = "1.5"
 bytes = "1.5"
 tracing = "0.1"

--- a/crates/rtmp/src/command_messages/mod.rs
+++ b/crates/rtmp/src/command_messages/mod.rs
@@ -5,6 +5,7 @@ use netstream::NetStreamCommand;
 use on_status::OnStatus;
 use scuffle_amf0::Amf0Value;
 use scuffle_bytes_util::StringCow;
+use serde_derive::Serialize;
 
 pub mod error;
 pub mod netconnection;
@@ -60,7 +61,7 @@ pub struct UnknownCommand<'a> {
 }
 
 /// NetStream onStatus level (7.2.2.) and NetConnection connect result level (7.2.1.1.)
-#[derive(Debug, Clone, PartialEq, Eq, serde::Serialize)]
+#[derive(Debug, Clone, PartialEq, Eq, Serialize)]
 #[serde(rename_all = "camelCase")]
 pub enum CommandResultLevel {
     /// Warning level.

--- a/crates/rtmp/src/command_messages/netconnection/mod.rs
+++ b/crates/rtmp/src/command_messages/netconnection/mod.rs
@@ -4,6 +4,7 @@ use std::collections::HashMap;
 
 use scuffle_amf0::{Amf0Object, Amf0Value};
 use scuffle_bytes_util::StringCow;
+use serde_derive::{Deserialize, Serialize};
 
 use super::on_status::{OnStatus, OnStatusCode};
 use crate::command_messages::CommandResultLevel;
@@ -16,7 +17,7 @@ pub mod writer;
 /// Defined by:
 /// - Legacy RTMP spec, 7.2.1.1
 /// - Enhanced RTMP spec, page 36-37, Enhancing NetConnection connect Command
-#[derive(Debug, Clone, PartialEq, serde::Deserialize)]
+#[derive(Debug, Clone, PartialEq, Deserialize)]
 #[serde(bound = "'a: 'de")]
 pub struct NetConnectionCommandConnect<'a> {
     /// Tells the server application name the client is connected to.
@@ -70,7 +71,7 @@ pub struct NetConnectionCommandConnectResult<'a> {
 ///
 /// Defined by:
 /// - Legacy RTMP spec, 7.2.1.1
-#[derive(Debug, Clone, PartialEq, serde::Serialize)]
+#[derive(Debug, Clone, PartialEq, Serialize)]
 #[serde(rename_all = "camelCase")]
 pub struct NetConnectionCommandConnectResultProperties<'a> {
     /// Flash Media Server version.

--- a/crates/rtmp/src/command_messages/netstream/mod.rs
+++ b/crates/rtmp/src/command_messages/netstream/mod.rs
@@ -2,6 +2,7 @@
 
 use scuffle_amf0::{Amf0Object, Amf0Value};
 use scuffle_bytes_util::StringCow;
+use serde_derive::{Deserialize, Serialize};
 
 pub mod reader;
 
@@ -69,7 +70,7 @@ pub enum NetStreamCommand<'a> {
 /// Type of publishing.
 ///
 /// Appears as part of the [`NetStreamCommand::Publish`] command.
-#[derive(Debug, Clone, PartialEq, Eq, serde::Deserialize, serde::Serialize)]
+#[derive(Debug, Clone, PartialEq, Eq, Deserialize, Serialize)]
 #[serde(rename_all = "camelCase")]
 pub enum NetStreamCommandPublishPublishingType<'a> {
     /// Citing the legacy RTMP spec, page 46:

--- a/crates/rtmp/src/command_messages/on_status/mod.rs
+++ b/crates/rtmp/src/command_messages/on_status/mod.rs
@@ -9,13 +9,14 @@
 use nutype_enum::nutype_enum;
 use scuffle_amf0::Amf0Object;
 use scuffle_bytes_util::StringCow;
+use serde_derive::Serialize;
 
 use crate::command_messages::CommandResultLevel;
 
 pub mod writer;
 
 /// The `onStatus` command is used to send status information from the server to the client.
-#[derive(Debug, Clone, PartialEq, serde::Serialize)]
+#[derive(Debug, Clone, PartialEq, Serialize)]
 #[serde(rename_all = "camelCase")]
 pub struct OnStatus<'a> {
     /// The status code.

--- a/crates/settings/Cargo.toml
+++ b/crates/settings/Cargo.toml
@@ -22,8 +22,8 @@ required-features = ["cli"]
 config = { version = "0.15", default-features = false }
 clap = { version = "4", optional = true }
 minijinja = { version = "2.5", optional = true, features = ["json", "custom_syntax", "urlencode"] }
-serde = "1.0.219"
-serde_derive = "1.0.219"
+serde = "1"
+serde_derive = "1"
 thiserror = "2"
 anyhow = { version = "1.0", optional = true }
 scuffle-bootstrap = { workspace = true, optional = true }
@@ -32,7 +32,7 @@ scuffle-workspace-hack.workspace = true
 [dev-dependencies]
 # For examples:
 smart-default = "0.7"
-serde_derive = " 1.0.219"
+serde_derive = "1"
 
 [features]
 cli = ["clap"]

--- a/crates/settings/Cargo.toml
+++ b/crates/settings/Cargo.toml
@@ -22,17 +22,17 @@ required-features = ["cli"]
 config = { version = "0.15", default-features = false }
 clap = { version = "4", optional = true }
 minijinja = { version = "2.5", optional = true, features = ["json", "custom_syntax", "urlencode"] }
-serde = "1"
+serde = "1.0.219"
+serde_derive = "1.0.219"
 thiserror = "2"
 anyhow = { version = "1.0", optional = true }
 scuffle-bootstrap = { workspace = true, optional = true }
 scuffle-workspace-hack.workspace = true
 
 [dev-dependencies]
-serde = { version = "1", features = [ "derive" ] }
-
 # For examples:
 smart-default = "0.7"
+serde_derive = " 1.0.219"
 
 [features]
 cli = ["clap"]

--- a/crates/settings/examples/cli.rs
+++ b/crates/settings/examples/cli.rs
@@ -1,4 +1,4 @@
-#[derive(Debug, serde::Deserialize, smart_default::SmartDefault)]
+#[derive(Debug, serde_derive::Deserialize, smart_default::SmartDefault)]
 #[serde(default)]
 struct Config {
     #[default = "baz"]

--- a/crates/settings/src/lib.rs
+++ b/crates/settings/src/lib.rs
@@ -10,7 +10,7 @@
 //! ```rust
 //! // Define a config struct like this
 //! // You can use all of the serde attributes to customize the deserialization
-//! #[derive(serde::Deserialize)]
+//! #[derive(serde_derive::Deserialize)]
 //! struct MyConfig {
 //!     some_setting: String,
 //!     #[serde(default)]
@@ -40,7 +40,7 @@
 //! # fn test() -> Result<(), scuffle_settings::SettingsError> {
 //! // Define a config struct like this
 //! // You can use all of the serde attributes to customize the deserialization
-//! #[derive(serde::Deserialize)]
+//! #[derive(serde_derive::Deserialize)]
 //! struct MyConfig {
 //!     some_setting: String,
 //!     #[serde(default)]
@@ -328,7 +328,7 @@ pub mod macros {
 /// ## Example
 ///
 /// ```rust
-/// #[derive(serde::Deserialize)]
+/// #[derive(serde_derive::Deserialize)]
 /// struct MySettings {
 ///     key: String,
 /// }
@@ -354,11 +354,13 @@ macro_rules! bootstrap {
 #[cfg(test)]
 #[cfg_attr(all(test, coverage_nightly), coverage(off))]
 mod tests {
+    use serde_derive::Deserialize;
+
     #[cfg(feature = "cli")]
     use crate::Cli;
     use crate::{Options, parse_settings};
 
-    #[derive(Debug, serde::Deserialize)]
+    #[derive(Debug, Deserialize)]
     struct TestSettings {
         #[cfg_attr(not(feature = "cli"), allow(dead_code))]
         key: String,

--- a/dev-tools/xtask/Cargo.toml
+++ b/dev-tools/xtask/Cargo.toml
@@ -14,7 +14,8 @@ license = "MIT OR Apache-2.0"
 clap = { version = "4.5.23", features = ["derive", "env"] }
 cargo_metadata = "0.19.1"
 anyhow = "1.0"
-serde = { version = "1.0", features = ["derive"] }
+serde = "1.0.219"
+serde_derive = "1.0.219"
 serde_json = "1.0"
 toml_edit = { version = "0.22", features = ["serde"] }
 regex = "1.11.1"

--- a/dev-tools/xtask/Cargo.toml
+++ b/dev-tools/xtask/Cargo.toml
@@ -14,8 +14,8 @@ license = "MIT OR Apache-2.0"
 clap = { version = "4.5.23", features = ["derive", "env"] }
 cargo_metadata = "0.19.1"
 anyhow = "1.0"
-serde = "1.0.219"
-serde_derive = "1.0.219"
+serde = "1"
+serde_derive = "1"
 serde_json = "1.0"
 toml_edit = { version = "0.22", features = ["serde"] }
 regex = "1.11.1"

--- a/dev-tools/xtask/src/cmd/change_logs/util.rs
+++ b/dev-tools/xtask/src/cmd/change_logs/util.rs
@@ -28,7 +28,7 @@ impl Fragment {
     }
 }
 
-#[derive(Debug, Clone, serde::Deserialize)]
+#[derive(Debug, Clone, serde_derive::Deserialize)]
 #[serde(deny_unknown_fields)]
 pub struct PackageChangeLog {
     #[serde(skip, default)]

--- a/dev-tools/xtask/src/cmd/power_set/utils.rs
+++ b/dev-tools/xtask/src/cmd/power_set/utils.rs
@@ -2,7 +2,7 @@ use std::collections::{BTreeMap, BTreeSet};
 
 use anyhow::Context;
 
-#[derive(Debug, Clone, serde::Deserialize)]
+#[derive(Debug, Clone, serde_derive::Deserialize)]
 #[serde(default, deny_unknown_fields)]
 pub struct XTaskMetadata {
     /// Allows you to provide a list of combinations that should be skipped.


### PR DESCRIPTION
Uses `serde_derive` instead of serde's derive feature for improved compile times.

CLOUD-98