### PR TITLE
chore: add stale label

### DIFF
--- a/.github/labels.yaml
+++ b/.github/labels.yaml
@@ -36,3 +36,5 @@
   color: "a62b33"
 - name: "do-not-merge"
   color: "7d1700"
+- name: "stale"
+  color: "ffffff"


### PR DESCRIPTION
Add the `stale` label to label PRs that can't be merged for a reason that can not be easily resolved or is out of our control.