### PR TITLE
remove workspace-deps

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2588,11 +2588,11 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "be769465445e8c1474e9c5dac2018218498557af32d9ed057325ec9a41ae81bf"
 dependencies = [
  "heck",
- "itertools 0.13.0",
+ "itertools 0.14.0",
  "log",
  "multimap",
  "once_cell",
- "petgraph 0.6.5",
+ "petgraph 0.7.1",
  "prettyplease",
  "prost 0.13.5",
  "prost-types 0.13.5",
@@ -2621,7 +2621,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8a56d757972c98b346a9b766e3f02746cde6dd1cd1d1d563472929fdd74bec4d"
 dependencies = [
  "anyhow",
- "itertools 0.13.0",
+ "itertools 0.14.0",
  "proc-macro2",
  "quote",
  "syn",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -41,43 +41,44 @@ members = [
 resolver = "2"
 
 [workspace.dependencies]
-scuffle-aac = { path = "crates/aac", version = "0.1.2" }
-scuffle-amf0 = { path = "crates/amf0", version = "0.2.0" }
-scuffle-av1 = { path = "crates/av1", version = "0.1.2" }
-scuffle-batching = { path = "crates/batching", version = "0.1.2" }
-scuffle-bootstrap = { path = "crates/bootstrap", version = "0.1.2" }
-scuffle-bootstrap-derive = { path = "crates/bootstrap/derive", version = "0.1.2" }
-scuffle-bootstrap-telemetry = { path = "crates/bootstrap/telemetry", version = "0.2.1" }
-scuffle-bytes-util = { path = "crates/bytes-util", version = "0.1.2" }
-scuffle-context = { path = "crates/context", version = "0.1.2" }
-scuffle-expgolomb = { path = "crates/expgolomb", version = "0.1.2" }
-scuffle-ffmpeg = { path = "crates/ffmpeg", version = "0.3.0" }
-scuffle-flv = { path = "crates/flv", version = "0.2.0" }
-scuffle-future-ext = { path = "crates/future-ext", version = "0.1.2" }
-scuffle-http = { path = "crates/http", version = "0.2.1" }
-scuffle-metrics = { path = "crates/metrics", version = "0.2.0" }
-scuffle-metrics-derive = { path = "crates/metrics/derive", version = "0.1.2" }
-postcompile = { path = "crates/postcompile", version = "0.2.0" }
-scuffle-pprof = { path = "crates/pprof", version = "0.1.2" }
-scuffle-settings = { path = "crates/settings", version = "0.1.2" }
-scuffle-signal = { path = "crates/signal", version = "0.3.0" }
-nutype-enum = { path = "crates/nutype_enum", version = "0.1.3" }
-scuffle-h264 = { path = "crates/h264", version = "0.2.0" }
-scuffle-h265 = { path = "crates/h265", version = "0.2.0" }
-scuffle-mp4 = { path = "crates/mp4", version = "0.1.2" }
-scuffle-rtmp = { path = "crates/rtmp", version = "0.2.0" }
-scuffle-transmuxer = { path = "crates/transmuxer", version = "0.2.0" }
 scuffle-workspace-hack = { version = "0.1.0" }
-tinc = { path = "crates/tinc", version = "0.1.0" }
-tinc-cel = { path = "crates/tinc/cel", version = "0.0.1" }
-tinc-pb-prost = { path = "crates/tinc/pb-prost", version = "0.1.0" }
-tinc-build = { path = "crates/tinc/build", version = "0.1.0" }
-tinc-derive = { path = "crates/tinc/derive", version = "0.1.0" }
-openapiv3_1 = { path = "crates/openapiv3_1", version = "0.1.0" }
+
 
 [profile.release-debug]
 inherits = "release"
 debug = true
 
-[patch.crates-io.scuffle-workspace-hack]
-path = "crates/workspace-hack"
+[patch.crates-io]
+scuffle-workspace-hack.path = "crates/workspace-hack"
+scuffle-aac.path = "crates/aac"
+scuffle-amf0.path = "crates/amf0"
+scuffle-av1.path = "crates/av1"
+scuffle-batching.path = "crates/batching"
+scuffle-bootstrap.path = "crates/bootstrap"
+scuffle-bootstrap-derive.path = "crates/bootstrap/derive"
+scuffle-bootstrap-telemetry.path = "crates/bootstrap/telemetry"
+scuffle-bytes-util.path = "crates/bytes-util"
+scuffle-context.path = "crates/context"
+scuffle-expgolomb.path = "crates/expgolomb"
+scuffle-ffmpeg.path = "crates/ffmpeg"
+scuffle-flv.path = "crates/flv"
+scuffle-future-ext.path = "crates/future-ext"
+scuffle-http.path = "crates/http"
+scuffle-metrics.path = "crates/metrics"
+scuffle-metrics-derive.path = "crates/metrics/derive"
+postcompile.path = "crates/postcompile"
+scuffle-pprof.path = "crates/pprof"
+scuffle-settings.path = "crates/settings"
+scuffle-signal.path = "crates/signal"
+nutype-enum.path = "crates/nutype_enum"
+scuffle-h264.path = "crates/h264"
+scuffle-h265.path = "crates/h265"
+scuffle-mp4.path = "crates/mp4"
+scuffle-rtmp.path = "crates/rtmp"
+scuffle-transmuxer.path = "crates/transmuxer"
+tinc.path = "crates/tinc"
+tinc-cel.path = "crates/tinc/cel"
+tinc-pb-prost.path = "crates/tinc/pb-prost"
+tinc-build.path = "crates/tinc/build"
+tinc-derive.path = "crates/tinc/derive"
+openapiv3_1.path = "crates/openapiv3_1"

--- a/crates/aac/Cargo.toml
+++ b/crates/aac/Cargo.toml
@@ -18,5 +18,5 @@ bytes = "1.5"
 byteorder = "1.5"
 num-traits = "0.2"
 num-derive = "0.4"
+scuffle-bytes-util = "0.1.1"
 scuffle-workspace-hack.workspace = true
-scuffle-bytes-util.workspace = true

--- a/crates/amf0/Cargo.toml
+++ b/crates/amf0/Cargo.toml
@@ -18,7 +18,7 @@ num-traits = "0.2"
 num-derive = "0.4"
 thiserror = "2.0"
 bytestring = "1.4.0"
-scuffle-bytes-util = { workspace = true }
+scuffle-bytes-util = "0.1.1"
 scuffle-workspace-hack.workspace = true
 
 [dev-dependencies]

--- a/crates/av1/Cargo.toml
+++ b/crates/av1/Cargo.toml
@@ -16,7 +16,7 @@ unexpected_cfgs = { level = "warn", check-cfg = ['cfg(coverage_nightly)'] }
 [dependencies]
 bytes = "1.5"
 byteorder = "1.5"
-scuffle-bytes-util.workspace = true
+scuffle-bytes-util = "0.1.1"
 scuffle-workspace-hack.workspace = true
 
 [dev-dependencies]

--- a/crates/bootstrap/Cargo.toml
+++ b/crates/bootstrap/Cargo.toml
@@ -31,15 +31,15 @@ tokio = { version = "1", features = ["full"] }
 futures = "0.3"
 pin-project-lite = "0.2"
 
-scuffle-context.workspace = true
-scuffle-bootstrap-derive.workspace = true
+scuffle-context = "0.1.2"
+scuffle-bootstrap-derive = "0.1.2"
 scuffle-workspace-hack.workspace = true
 
 [dev-dependencies]
 insta = "1.42"
-postcompile.workspace = true
-scuffle-future-ext.workspace = true
-scuffle-signal = { workspace = true, features = ["bootstrap"] }
+postcompile = "0.2.0"
+scuffle-future-ext = "0.1.1"
+scuffle-signal = { version = "0.3.0", features = ["bootstrap"] }
 
 # For examples:
 serde = "1"
@@ -47,4 +47,4 @@ serde_derive = "1"
 smart-default = "0.7"
 tracing = "0.1"
 tracing-subscriber = "0.3"
-scuffle-settings = { workspace = true, features = ["bootstrap"] }
+scuffle-settings = { version = "0.1.1", features = ["bootstrap"] }

--- a/crates/bootstrap/telemetry/Cargo.toml
+++ b/crates/bootstrap/telemetry/Cargo.toml
@@ -30,14 +30,14 @@ opentelemetry_sdk = { version = "0.29", optional = true }
 opentelemetry-appender-tracing = { version = "0.29", optional = true }
 tracing-opentelemetry = { version = "0.30", optional = true }
 
-scuffle-bootstrap.workspace = true
-scuffle-context.workspace = true
-scuffle-http.workspace = true
-scuffle-pprof = { workspace = true, optional = true }
+scuffle-bootstrap = "0.1.2"
+scuffle-context = "0.1.0"
+scuffle-http = "0.2.1"
+scuffle-pprof = { version= "0.1.0", optional = true }
 scuffle-workspace-hack.workspace = true
 
 [dev-dependencies]
-scuffle-metrics.workspace = true
+scuffle-metrics = "0.2.0"
 reqwest = { version = "0.12.12", default-features = false }
 
 [features]

--- a/crates/context/Cargo.toml
+++ b/crates/context/Cargo.toml
@@ -22,4 +22,4 @@ scuffle-workspace-hack.workspace = true
 
 [dev-dependencies]
 tokio-test = "0.4.4"
-scuffle-future-ext.workspace = true
+scuffle-future-ext = "0.1.1"

--- a/crates/expgolomb/Cargo.toml
+++ b/crates/expgolomb/Cargo.toml
@@ -14,7 +14,7 @@ keywords = ["exp-golomb", "video", "h264", "h265"]
 unexpected_cfgs = { level = "warn", check-cfg = ['cfg(coverage_nightly)'] }
 
 [dependencies]
-scuffle-bytes-util.workspace = true
+scuffle-bytes-util = "0.1.1"
 scuffle-workspace-hack.workspace = true
 
 [dev-dependencies]

--- a/crates/ffmpeg/Cargo.toml
+++ b/crates/ffmpeg/Cargo.toml
@@ -16,24 +16,24 @@ unexpected_cfgs = { level = "warn", check-cfg = ['cfg(coverage_nightly)'] }
 [dependencies]
 libc = "0.2"
 bytes = { optional = true, version = "1" }
-tokio = { optional = true, version = "1", features = ["sync"]}
+tokio = { optional = true, version = "1", features = ["sync"] }
 crossbeam-channel = { optional = true, version = "0.5.13" }
 tracing = { optional = true, version = "0.1" }
 arc-swap = { version = "1.7" }
 rusty_ffmpeg = "0.16.1"
 scuffle-workspace-hack.workspace = true
-nutype-enum.workspace = true
+nutype-enum = "0.1.2"
 rand = "0.9"
 bon = "3.3.2"
 thiserror = "2.0"
 va_list = "0.2"
 
 [dev-dependencies]
-insta = {version = "1.42", features = ["filters"]}
+insta = { version = "1.42", features = ["filters"] }
 tempfile = "3.15"
 tracing-test = "0.2"
 tracing-subscriber = "0.3"
-scuffle-mp4.workspace = true
+scuffle-mp4 = "0.1.1"
 sha2 = "0.10"
 bytes = "1"
 
@@ -49,16 +49,9 @@ default = ["link_system_ffmpeg"]
 [package.metadata.xtask.powerset]
 # Note: `link_system_ffmpeg` nor `link_vcpkg_ffmpeg` are additive features because
 # they change the build.rs and therefore require a full rebuild of the crate.
-additive-features = [
-    "channel",
-    "tokio-channel",
-    "crossbeam-channel",
-    "tracing",
-]
+additive-features = ["channel", "tokio-channel", "crossbeam-channel", "tracing"]
 
-always_include_features = [
-    "link_system_ffmpeg",
-]
+always_include_features = ["link_system_ffmpeg"]
 
 [package.metadata.docs.rs]
 features = ["channel", "tokio-channel", "crossbeam-channel", "tracing"]

--- a/crates/flv/Cargo.toml
+++ b/crates/flv/Cargo.toml
@@ -23,13 +23,13 @@ num-derive = "0.4"
 thiserror = "2.0"
 bitmask-enum = "2.2.5"
 
-scuffle-h264.workspace = true
-scuffle-h265.workspace = true
-scuffle-aac.workspace = true
-scuffle-bytes-util.workspace = true
-scuffle-av1.workspace = true
-scuffle-amf0 = { workspace = true, features = ["serde"] }
-nutype-enum.workspace = true
+scuffle-h264 = "0.2.0"
+scuffle-h265 = "0.2.0"
+scuffle-aac = "0.1.2"
+scuffle-bytes-util = "0.1.2"
+scuffle-av1 = "0.1.2"
+scuffle-amf0 = { version = "0.2.0", features = ["serde"] }
+nutype-enum = "0.1.2"
 scuffle-workspace-hack.workspace = true
 
 [dev-dependencies]

--- a/crates/h264/Cargo.toml
+++ b/crates/h264/Cargo.toml
@@ -16,10 +16,10 @@ unexpected_cfgs = { level = "warn", check-cfg = ['cfg(coverage_nightly)'] }
 [dependencies]
 bytes = "1.5"
 byteorder = "1.5"
-scuffle-expgolomb.workspace = true
-scuffle-bytes-util.workspace = true
+scuffle-expgolomb = "0.1.1"
+scuffle-bytes-util = "0.1.1"
 scuffle-workspace-hack.workspace = true
-nutype-enum.workspace = true
+nutype-enum = "0.1.2"
 
 [dev-dependencies]
 insta = "1.42"

--- a/crates/h265/Cargo.toml
+++ b/crates/h265/Cargo.toml
@@ -17,9 +17,9 @@ unexpected_cfgs = { level = "warn", check-cfg = ['cfg(coverage_nightly)'] }
 bytes = "1.5"
 byteorder = "1.5"
 bitflags = "2.9.0"
-scuffle-expgolomb.workspace = true
-scuffle-bytes-util.workspace = true
-nutype-enum.workspace = true
+scuffle-expgolomb = "0.1.1"
+scuffle-bytes-util = "0.1.1"
+nutype-enum = "0.1.3"
 scuffle-workspace-hack.workspace = true
 
 [dev-dependencies]

--- a/crates/http/Cargo.toml
+++ b/crates/http/Cargo.toml
@@ -34,7 +34,7 @@ thiserror = "2.0.11"
 futures = { version = "0.3.31", default-features = false, features = ["alloc"]}
 bon = "3.3.2"
 pin-project-lite = "0.2.16"
-scuffle-context.workspace = true
+scuffle-context = "0.1.1"
 
 # HTTP parsing
 http = "1.2.0"
@@ -69,7 +69,7 @@ reqwest = { version = "0.12.15", default-features = false, features = ["rustls-t
 axum = { version = "0.8.1", features = ["ws"]}
 rustls-pemfile = "2.2.0"
 tokio-test = "0.4.4"
-scuffle-future-ext.workspace = true
+scuffle-future-ext = "0.1.1"
 
 # For examples:
 tokio = { version = "1.43.0", features = ["full"] }

--- a/crates/metrics/Cargo.toml
+++ b/crates/metrics/Cargo.toml
@@ -25,16 +25,20 @@ required-features = ["default"]
 
 [dependencies]
 prometheus-client = { version = "0.23", optional = true }
-opentelemetry = { version = "0.29", default-features = false, features = ["metrics"] }
-opentelemetry_sdk = { version = "0.29", default-features = false, features = ["metrics"] }
-scuffle-metrics-derive.workspace = true
+opentelemetry = { version = "0.29", default-features = false, features = [
+    "metrics",
+] }
+opentelemetry_sdk = { version = "0.29", default-features = false, features = [
+    "metrics",
+] }
+scuffle-metrics-derive = "0.1.1"
 tracing = { version = "0.1", optional = true }
 parking_lot = "0.12"
 scuffle-workspace-hack.workspace = true
 
 [dev-dependencies]
 insta = "1.42.0"
-postcompile.workspace = true
+postcompile = "0.2.0"
 
 # For examples:
 tokio = { version = "1", features = ["full"] }
@@ -51,9 +55,4 @@ all-features = true
 rustdoc-args = ["--cfg", "docsrs"]
 
 [package.metadata.xtask.powerset]
-additive-features = [
-    "prometheus",
-    "tracing",
-    "internal-logs",
-    "default",
-]
+additive-features = ["prometheus", "tracing", "internal-logs", "default"]

--- a/crates/metrics/derive/Cargo.toml
+++ b/crates/metrics/derive/Cargo.toml
@@ -21,4 +21,4 @@ proc-macro2 = "1"
 scuffle-workspace-hack.workspace = true
 
 [dev-dependencies]
-scuffle-metrics.workspace = true
+scuffle-metrics = "0.2.0"

--- a/crates/mp4/Cargo.toml
+++ b/crates/mp4/Cargo.toml
@@ -17,11 +17,11 @@ fixed = "1.24"
 paste = "1.0"
 
 
-scuffle-h264.workspace = true
-scuffle-h265.workspace = true
-scuffle-av1.workspace = true
-scuffle-aac.workspace = true
-scuffle-bytes-util.workspace = true
+scuffle-h264 = "0.2.0"
+scuffle-h265 = "0.2.0"
+scuffle-av1 = "0.1.2"
+scuffle-aac = "0.1.2"
+scuffle-bytes-util = "0.1.2"
 scuffle-workspace-hack.workspace = true
 
 [dev-dependencies]

--- a/crates/rtmp/Cargo.toml
+++ b/crates/rtmp/Cargo.toml
@@ -11,7 +11,10 @@ license = "MIT OR Apache-2.0"
 keywords = ["rtmp", "server", "streaming"]
 
 [lints.rust]
-unexpected_cfgs = { level = "warn", check-cfg = ['cfg(coverage_nightly)', 'cfg(valgrind)'] }
+unexpected_cfgs = { level = "warn", check-cfg = [
+  'cfg(coverage_nightly)',
+  'cfg(valgrind)',
+] }
 
 [[example]]
 name = "scuffle-rtmp-basic"
@@ -34,11 +37,11 @@ num-traits = "0.2"
 num-derive = "0.4"
 bitmask-enum = "2.2.5"
 
-nutype-enum.workspace = true
-scuffle-amf0 = { workspace = true, features = ["serde"] }
-scuffle-bytes-util.workspace = true
-scuffle-future-ext.workspace = true
-scuffle-context.workspace = true
+nutype-enum = "0.1.2"
+scuffle-amf0 = { version = "0.2.0", features = ["serde"] }
+scuffle-bytes-util = "0.1.1"
+scuffle-future-ext = "0.1.1"
+scuffle-context = "0.1.1"
 scuffle-workspace-hack.workspace = true
 
 [dev-dependencies]
@@ -48,4 +51,4 @@ serde_json = "1.0"
 # For examples:
 tracing = "0.1.41"
 tracing-subscriber = "0.3.19"
-scuffle-flv = { workspace = true }
+scuffle-flv = "0.2.0"

--- a/crates/settings/Cargo.toml
+++ b/crates/settings/Cargo.toml
@@ -26,7 +26,7 @@ serde = "1"
 serde_derive = "1"
 thiserror = "2"
 anyhow = { version = "1.0", optional = true }
-scuffle-bootstrap = { workspace = true, optional = true }
+scuffle-bootstrap = { optional = true, version = "0.1.1"}
 scuffle-workspace-hack.workspace = true
 
 [dev-dependencies]

--- a/crates/signal/Cargo.toml
+++ b/crates/signal/Cargo.toml
@@ -15,8 +15,8 @@ unexpected_cfgs = { level = "warn", check-cfg = ['cfg(coverage_nightly)', 'cfg(v
 
 [dependencies]
 tokio = { version = "1", default-features = false, features = ["signal"] }
-scuffle-bootstrap = { workspace = true, optional = true }
-scuffle-context = { workspace = true, optional = true }
+scuffle-bootstrap = { optional = true, version = "0.1.1" }
+scuffle-context = { optional = true, version = "0.1.1" }
 anyhow = { version = "1", optional = true }
 scuffle-workspace-hack.workspace = true
 
@@ -24,7 +24,7 @@ scuffle-workspace-hack.workspace = true
 tokio = { version = "1.41.1", features = ["full"] }
 tokio-test = "0.4"
 futures = "0.3"
-scuffle-future-ext.workspace = true
+scuffle-future-ext = "0.1.1"
 libc = "0.2"
 
 [target.'cfg(windows)'.dev-dependencies]

--- a/crates/tinc/Cargo.toml
+++ b/crates/tinc/Cargo.toml
@@ -40,9 +40,9 @@ num-traits = "0.2.19"
 regex = "1"
 linear-map = "1.2.0"
 
-tinc-derive.workspace = true
-openapiv3_1.workspace = true
-tinc-cel = { workspace = true, features = ["runtime"] }
+tinc-derive = "0.1.0"
+openapiv3_1 = "0.1.0"
+tinc-cel = { version = "0.0.1", features = ["runtime"] }
 
 scuffle-workspace-hack.workspace = true
 

--- a/crates/tinc/build/Cargo.toml
+++ b/crates/tinc/build/Cargo.toml
@@ -11,13 +11,16 @@ license = "MIT OR Apache-2.0"
 keywords = ["grpc", "protobuf", "tonic", "codegen"]
 
 [lints.rust]
-unexpected_cfgs = { level = "warn", check-cfg = ['cfg(coverage_nightly)', 'cfg(valgrind)'] }
+unexpected_cfgs = { level = "warn", check-cfg = [
+  'cfg(coverage_nightly)',
+  'cfg(valgrind)',
+] }
 
 [dependencies]
 scuffle-workspace-hack.workspace = true
-tinc-pb-prost.workspace = true
-tinc-cel.workspace = true
-openapiv3_1 = { workspace = true, features = ["debug"] }
+tinc-pb-prost = "0.1.0"
+tinc-cel = "0.0.1"
+openapiv3_1 = { version = "0.1.0", features = ["debug"] }
 tonic-build = { version = "0.13.0", default-features = false }
 prost = { version = "0.13.5", optional = true }
 prost-build = { version = "0.13.5", optional = true }
@@ -30,7 +33,7 @@ syn = "2"
 proc-macro2 = "1"
 prettyplease = "0.2"
 indexmap = "2.9.0"
-cel-parser = { version = "0.8.0" }
+cel-parser = "0.8.0"
 serde_json = "1"
 serde_derive = "1"
 serde = "1"
@@ -43,7 +46,7 @@ base64 = "0.22"
 
 [dev-dependencies]
 insta = "1"
-postcompile.workspace = true
+postcompile = "0.2.0"
 
 [features]
 default = ["prost"]

--- a/crates/tinc/build/src/codegen/cel/functions/all.rs
+++ b/crates/tinc/build/src/codegen/cel/functions/all.rs
@@ -299,7 +299,7 @@ mod tests {
             postcompile::config! {
                 test: true,
                 dependencies: vec![
-                    postcompile::Dependency::workspace("tinc"),
+                    postcompile::Dependency::version("tinc", "*"),
                 ],
             },
             quote! {
@@ -353,7 +353,7 @@ mod tests {
             postcompile::config! {
                 test: true,
                 dependencies: vec![
-                    postcompile::Dependency::workspace("tinc"),
+                    postcompile::Dependency::version("tinc", "*"),
                 ],
             },
             quote! {
@@ -416,7 +416,7 @@ mod tests {
             postcompile::config! {
                 test: true,
                 dependencies: vec![
-                    postcompile::Dependency::workspace("tinc"),
+                    postcompile::Dependency::version("tinc", "*"),
                 ],
             },
             quote! {
@@ -464,7 +464,7 @@ mod tests {
             postcompile::config! {
                 test: true,
                 dependencies: vec![
-                    postcompile::Dependency::workspace("tinc"),
+                    postcompile::Dependency::version("tinc", "*"),
                 ],
             },
             quote! {
@@ -511,7 +511,7 @@ mod tests {
             postcompile::config! {
                 test: true,
                 dependencies: vec![
-                    postcompile::Dependency::workspace("tinc"),
+                    postcompile::Dependency::version("tinc", "*"),
                 ],
             },
             quote! {

--- a/crates/tinc/build/src/codegen/cel/functions/bytes.rs
+++ b/crates/tinc/build/src/codegen/cel/functions/bytes.rs
@@ -110,7 +110,7 @@ mod tests {
             postcompile::config! {
                 test: true,
                 dependencies: vec![
-                    postcompile::Dependency::workspace("tinc"),
+                    postcompile::Dependency::version("tinc", "*"),
                 ],
             },
             quote! {

--- a/crates/tinc/build/src/codegen/cel/functions/contains.rs
+++ b/crates/tinc/build/src/codegen/cel/functions/contains.rs
@@ -154,7 +154,7 @@ mod tests {
             postcompile::config! {
                 test: true,
                 dependencies: vec![
-                    postcompile::Dependency::workspace("tinc"),
+                    postcompile::Dependency::version("tinc", "*"),
                 ],
             },
             quote! {
@@ -197,7 +197,7 @@ mod tests {
             postcompile::config! {
                 test: true,
                 dependencies: vec![
-                    postcompile::Dependency::workspace("tinc"),
+                    postcompile::Dependency::version("tinc", "*"),
                 ],
             },
             quote! {
@@ -251,7 +251,7 @@ mod tests {
             postcompile::config! {
                 test: true,
                 dependencies: vec![
-                    postcompile::Dependency::workspace("tinc"),
+                    postcompile::Dependency::version("tinc", "*"),
                 ],
             },
             quote! {

--- a/crates/tinc/build/src/codegen/cel/functions/double.rs
+++ b/crates/tinc/build/src/codegen/cel/functions/double.rs
@@ -106,7 +106,7 @@ mod tests {
             postcompile::config! {
                 test: true,
                 dependencies: vec![
-                    postcompile::Dependency::workspace("tinc"),
+                    postcompile::Dependency::version("tinc", "*"),
                 ],
             },
             quote::quote! {

--- a/crates/tinc/build/src/codegen/cel/functions/ends_with.rs
+++ b/crates/tinc/build/src/codegen/cel/functions/ends_with.rs
@@ -121,7 +121,7 @@ mod tests {
             postcompile::config! {
                 test: true,
                 dependencies: vec![
-                    postcompile::Dependency::workspace("tinc"),
+                    postcompile::Dependency::version("tinc", "*"),
                 ],
             },
             quote::quote! {

--- a/crates/tinc/build/src/codegen/cel/functions/enum_.rs
+++ b/crates/tinc/build/src/codegen/cel/functions/enum_.rs
@@ -148,7 +148,7 @@ mod tests {
             postcompile::config! {
                 test: true,
                 dependencies: vec![
-                    postcompile::Dependency::workspace("tinc"),
+                    postcompile::Dependency::version("tinc", "*"),
                 ],
             },
             quote::quote! {

--- a/crates/tinc/build/src/codegen/cel/functions/exists.rs
+++ b/crates/tinc/build/src/codegen/cel/functions/exists.rs
@@ -240,7 +240,7 @@ mod tests {
             postcompile::config! {
                 test: true,
                 dependencies: vec![
-                    postcompile::Dependency::workspace("tinc"),
+                    postcompile::Dependency::version("tinc", "*"),
                 ],
             },
             quote! {
@@ -294,7 +294,7 @@ mod tests {
             postcompile::config! {
                 test: true,
                 dependencies: vec![
-                    postcompile::Dependency::workspace("tinc"),
+                    postcompile::Dependency::version("tinc", "*"),
                 ],
             },
             quote! {
@@ -333,7 +333,7 @@ mod tests {
             postcompile::config! {
                 test: true,
                 dependencies: vec![
-                    postcompile::Dependency::workspace("tinc"),
+                    postcompile::Dependency::version("tinc", "*"),
                 ],
             },
             quote! {
@@ -387,7 +387,7 @@ mod tests {
             postcompile::config! {
                 test: true,
                 dependencies: vec![
-                    postcompile::Dependency::workspace("tinc"),
+                    postcompile::Dependency::version("tinc", "*"),
                 ],
             },
             quote! {

--- a/crates/tinc/build/src/codegen/cel/functions/exists_one.rs
+++ b/crates/tinc/build/src/codegen/cel/functions/exists_one.rs
@@ -272,7 +272,7 @@ mod tests {
             postcompile::config! {
                 test: true,
                 dependencies: vec![
-                    postcompile::Dependency::workspace("tinc"),
+                    postcompile::Dependency::version("tinc", "*"),
                 ],
             },
             quote! {
@@ -326,7 +326,7 @@ mod tests {
             postcompile::config! {
                 test: true,
                 dependencies: vec![
-                    postcompile::Dependency::workspace("tinc"),
+                    postcompile::Dependency::version("tinc", "*"),
                 ],
             },
             quote! {
@@ -365,7 +365,7 @@ mod tests {
             postcompile::config! {
                 test: true,
                 dependencies: vec![
-                    postcompile::Dependency::workspace("tinc"),
+                    postcompile::Dependency::version("tinc", "*"),
                 ],
             },
             quote! {
@@ -419,7 +419,7 @@ mod tests {
             postcompile::config! {
                 test: true,
                 dependencies: vec![
-                    postcompile::Dependency::workspace("tinc"),
+                    postcompile::Dependency::version("tinc", "*"),
                 ],
             },
             quote! {

--- a/crates/tinc/build/src/codegen/cel/functions/filter.rs
+++ b/crates/tinc/build/src/codegen/cel/functions/filter.rs
@@ -344,7 +344,7 @@ mod tests {
             postcompile::config! {
                 test: true,
                 dependencies: vec![
-                    postcompile::Dependency::workspace("tinc"),
+                    postcompile::Dependency::version("tinc", "*"),
                 ],
             },
             quote! {
@@ -393,7 +393,7 @@ mod tests {
             postcompile::config! {
                 test: true,
                 dependencies: vec![
-                    postcompile::Dependency::workspace("tinc"),
+                    postcompile::Dependency::version("tinc", "*"),
                 ],
             },
             quote! {
@@ -432,7 +432,7 @@ mod tests {
             postcompile::config! {
                 test: true,
                 dependencies: vec![
-                    postcompile::Dependency::workspace("tinc"),
+                    postcompile::Dependency::version("tinc", "*"),
                 ],
             },
             quote! {
@@ -479,7 +479,7 @@ mod tests {
             postcompile::config! {
                 test: true,
                 dependencies: vec![
-                    postcompile::Dependency::workspace("tinc"),
+                    postcompile::Dependency::version("tinc", "*"),
                 ],
             },
             quote! {

--- a/crates/tinc/build/src/codegen/cel/functions/int.rs
+++ b/crates/tinc/build/src/codegen/cel/functions/int.rs
@@ -106,7 +106,7 @@ mod tests {
             postcompile::config! {
                 test: true,
                 dependencies: vec![
-                    postcompile::Dependency::workspace("tinc"),
+                    postcompile::Dependency::version("tinc", "*"),
                 ],
             },
             quote::quote! {

--- a/crates/tinc/build/src/codegen/cel/functions/is_email.rs
+++ b/crates/tinc/build/src/codegen/cel/functions/is_email.rs
@@ -124,7 +124,7 @@ mod tests {
             postcompile::config! {
                 test: true,
                 dependencies: vec![
-                    postcompile::Dependency::workspace("tinc"),
+                    postcompile::Dependency::version("tinc", "*"),
                 ],
             },
             quote::quote! {

--- a/crates/tinc/build/src/codegen/cel/functions/is_hostname.rs
+++ b/crates/tinc/build/src/codegen/cel/functions/is_hostname.rs
@@ -124,7 +124,7 @@ mod tests {
             postcompile::config! {
                 test: true,
                 dependencies: vec![
-                    postcompile::Dependency::workspace("tinc"),
+                    postcompile::Dependency::version("tinc", "*"),
                 ],
             },
             quote::quote! {

--- a/crates/tinc/build/src/codegen/cel/functions/is_ipv4.rs
+++ b/crates/tinc/build/src/codegen/cel/functions/is_ipv4.rs
@@ -124,7 +124,7 @@ mod tests {
             postcompile::config! {
                 test: true,
                 dependencies: vec![
-                    postcompile::Dependency::workspace("tinc"),
+                    postcompile::Dependency::version("tinc", "*"),
                 ],
             },
             quote::quote! {

--- a/crates/tinc/build/src/codegen/cel/functions/is_ipv6.rs
+++ b/crates/tinc/build/src/codegen/cel/functions/is_ipv6.rs
@@ -124,7 +124,7 @@ mod tests {
             postcompile::config! {
                 test: true,
                 dependencies: vec![
-                    postcompile::Dependency::workspace("tinc"),
+                    postcompile::Dependency::version("tinc", "*"),
                 ],
             },
             quote::quote! {

--- a/crates/tinc/build/src/codegen/cel/functions/is_uri.rs
+++ b/crates/tinc/build/src/codegen/cel/functions/is_uri.rs
@@ -136,7 +136,7 @@ mod tests {
             postcompile::config! {
                 test: true,
                 dependencies: vec![
-                    postcompile::Dependency::workspace("tinc"),
+                    postcompile::Dependency::version("tinc", "*"),
                 ],
             },
             quote::quote! {

--- a/crates/tinc/build/src/codegen/cel/functions/is_uuid.rs
+++ b/crates/tinc/build/src/codegen/cel/functions/is_uuid.rs
@@ -124,7 +124,7 @@ mod tests {
             postcompile::config! {
                 test: true,
                 dependencies: vec![
-                    postcompile::Dependency::workspace("tinc"),
+                    postcompile::Dependency::version("tinc", "*"),
                 ],
             },
             quote::quote! {

--- a/crates/tinc/build/src/codegen/cel/functions/map.rs
+++ b/crates/tinc/build/src/codegen/cel/functions/map.rs
@@ -320,7 +320,7 @@ mod tests {
             postcompile::config! {
                 test: true,
                 dependencies: vec![
-                    postcompile::Dependency::workspace("tinc"),
+                    postcompile::Dependency::version("tinc", "*"),
                 ],
             },
             quote! {
@@ -371,7 +371,7 @@ mod tests {
             postcompile::config! {
                 test: true,
                 dependencies: vec![
-                    postcompile::Dependency::workspace("tinc"),
+                    postcompile::Dependency::version("tinc", "*"),
                 ],
             },
             quote! {
@@ -412,7 +412,7 @@ mod tests {
             postcompile::config! {
                 test: true,
                 dependencies: vec![
-                    postcompile::Dependency::workspace("tinc"),
+                    postcompile::Dependency::version("tinc", "*"),
                 ],
             },
             quote! {
@@ -462,7 +462,7 @@ mod tests {
             postcompile::config! {
                 test: true,
                 dependencies: vec![
-                    postcompile::Dependency::workspace("tinc"),
+                    postcompile::Dependency::version("tinc", "*"),
                 ],
             },
             quote! {

--- a/crates/tinc/build/src/codegen/cel/functions/matches.rs
+++ b/crates/tinc/build/src/codegen/cel/functions/matches.rs
@@ -147,7 +147,7 @@ mod tests {
             postcompile::config! {
                 test: true,
                 dependencies: vec![
-                    postcompile::Dependency::workspace("tinc"),
+                    postcompile::Dependency::version("tinc", "*"),
                 ],
             },
             quote! {

--- a/crates/tinc/build/src/codegen/cel/functions/size.rs
+++ b/crates/tinc/build/src/codegen/cel/functions/size.rs
@@ -118,7 +118,7 @@ mod tests {
             postcompile::config! {
                 test: true,
                 dependencies: vec![
-                    postcompile::Dependency::workspace("tinc"),
+                    postcompile::Dependency::version("tinc", "*"),
                 ],
             },
             quote::quote! {
@@ -154,7 +154,7 @@ mod tests {
             postcompile::config! {
                 test: true,
                 dependencies: vec![
-                    postcompile::Dependency::workspace("tinc"),
+                    postcompile::Dependency::version("tinc", "*"),
                 ],
             },
             quote::quote! {
@@ -200,7 +200,7 @@ mod tests {
             postcompile::config! {
                 test: true,
                 dependencies: vec![
-                    postcompile::Dependency::workspace("tinc"),
+                    postcompile::Dependency::version("tinc", "*"),
                 ],
             },
             quote::quote! {

--- a/crates/tinc/build/src/codegen/cel/functions/starts_with.rs
+++ b/crates/tinc/build/src/codegen/cel/functions/starts_with.rs
@@ -121,7 +121,7 @@ mod tests {
             postcompile::config! {
                 test: true,
                 dependencies: vec![
-                    postcompile::Dependency::workspace("tinc"),
+                    postcompile::Dependency::version("tinc", "*"),
                 ],
             },
             quote::quote! {

--- a/crates/tinc/build/src/codegen/cel/functions/string.rs
+++ b/crates/tinc/build/src/codegen/cel/functions/string.rs
@@ -200,7 +200,7 @@ mod tests {
             postcompile::config! {
                 test: true,
                 dependencies: vec![
-                    postcompile::Dependency::workspace("tinc"),
+                    postcompile::Dependency::version("tinc", "*"),
                 ],
             },
             quote::quote! {

--- a/crates/tinc/build/src/codegen/cel/functions/uint.rs
+++ b/crates/tinc/build/src/codegen/cel/functions/uint.rs
@@ -106,7 +106,7 @@ mod tests {
             postcompile::config! {
                 test: true,
                 dependencies: vec![
-                    postcompile::Dependency::workspace("tinc"),
+                    postcompile::Dependency::version("tinc", "*"),
                 ],
             },
             quote::quote! {

--- a/crates/tinc/integration/Cargo.toml
+++ b/crates/tinc/integration/Cargo.toml
@@ -8,7 +8,7 @@ license = "MIT OR Apache-2.0"
 unexpected_cfgs = { level = "warn", check-cfg = ['cfg(coverage_nightly)'] }
 
 [dev-dependencies]
-tinc.workspace = true
+tinc = "0.1.0"
 insta = { version = "1.30.0", features = ["json"] }
 serde_json = "1.0.115"
 serde = "1.0.215"
@@ -24,5 +24,5 @@ tonic = "0.13"
 rand = "0.9"
 
 [build-dependencies]
-tinc-build.workspace = true
+tinc-build = "0.1.0"
 prost-build = "0.13.5"

--- a/crates/transmuxer/Cargo.toml
+++ b/crates/transmuxer/Cargo.toml
@@ -15,13 +15,13 @@ byteorder = "1.5"
 bytes = "1.5"
 thiserror = "2.0.12"
 
-scuffle-h264.workspace = true
-scuffle-h265.workspace = true
-scuffle-mp4.workspace = true
-scuffle-aac.workspace = true
-scuffle-av1.workspace = true
-scuffle-flv.workspace = true
-scuffle-bytes-util.workspace = true
+scuffle-h264 = "0.2.0"
+scuffle-h265 = "0.2.0"
+scuffle-mp4 = "0.1.2"
+scuffle-aac = "0.1.2"
+scuffle-av1 = "0.1.2"
+scuffle-flv = "0.2.0"
+scuffle-bytes-util = "0.1.2"
 scuffle-workspace-hack.workspace = true
 
 [dev-dependencies]


### PR DESCRIPTION
@SimaoMoreira5228 's work for moving away from workspace deps.

The reason being is that we want to be able to select versions of workspace members in our crates more precisely. I added some fixes to post compile to fix build caching.