### PR TITLE
Set openapi-v3 version in tinc-build

### DIFF
--- a/crates/tinc/build/Cargo.toml
+++ b/crates/tinc/build/Cargo.toml
@@ -33,7 +33,7 @@ fmtools = "0.1"
 heck = "0.5.0"
 indexmap = "2.9.0"
 num-traits = "0.2.19"
-openapiv3_1 = { features = ["debug"], path = "../../openapiv3_1" }
+openapiv3_1 = { features = ["debug"], path = "../../openapiv3_1", version = "0.1.1" }
 prettyplease = "0.2"
 proc-macro2 = "1"
 prost = { optional = true, version = "0.13.5" }


### PR DESCRIPTION
Should fix the crates.io release which failed here: https://github.com/ScuffleCloud/scuffle/actions/runs/15039106693/job/42266458336