### PR TITLE
Start with i64::MIN for previous_dts to support negative DTS

### DIFF
--- a/changes.d/pr-493.toml
+++ b/changes.d/pr-493.toml
@@ -1,0 +1,4 @@
+[[scuffle-ffmpeg]]
+category = "fix"
+description = "fixed panic when receiving packet with negative DTS from encoder"
+authors = ["@zezic"]

--- a/crates/ffmpeg/src/encoder.rs
+++ b/crates/ffmpeg/src/encoder.rs
@@ -227,7 +227,7 @@ impl Encoder {
             outgoing_time_base,
             encoder,
             stream_index: ost.index(),
-            previous_dts: std::i64::MIN,
+            previous_dts: i64::MIN,
         })
     }
 


### PR DESCRIPTION
DTS can be negative when ffmpeg encoder generates packet. If we start from zero, then encoder wrapper may crash at assert: https://github.com/ScuffleCloud/scuffle/blob/main/crates/ffmpeg/src/encoder.rs#L264-L269