### PR TITLE
update fmt style

### DIFF
--- a/changes.d/pr-496.toml
+++ b/changes.d/pr-496.toml
@@ -1,0 +1,14 @@
+[[scuffle-amf0]]
+category = "chore"
+description = "update fmt style"
+authors = ["troykomodo"]
+
+[[scuffle-mp4]]
+category = "chore"
+description = "update fmt style"
+authors = ["troykomodo"]
+
+[[tinc]]
+category = "chore"
+description = "update fmt style"
+authors = ["troykomodo"]

--- a/crates/amf0/src/de/mod.rs
+++ b/crates/amf0/src/de/mod.rs
@@ -822,7 +822,10 @@ mod tests {
         #[derive(Deserialize, Debug, PartialEq)]
         enum Test {
             A(bool),
-            B { a: String, b: String },
+            B {
+                a: String,
+                b: String,
+            },
             C(bool, String),
         }
 

--- a/crates/amf0/src/decoder.rs
+++ b/crates/amf0/src/decoder.rs
@@ -21,8 +21,12 @@ pub struct Amf0Decoder<R> {
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub(crate) enum ObjectHeader<'a> {
     Object,
-    TypedObject { name: StringCow<'a> },
-    EcmaArray { size: u32 },
+    TypedObject {
+        name: StringCow<'a>,
+    },
+    EcmaArray {
+        size: u32,
+    },
 }
 
 impl<B> Amf0Decoder<scuffle_bytes_util::zero_copy::BytesBuf<B>>

--- a/crates/amf0/src/ser.rs
+++ b/crates/amf0/src/ser.rs
@@ -803,7 +803,10 @@ mod tests {
         #[derive(Serialize)]
         enum Test {
             A(bool),
-            B { a: String, b: String },
+            B {
+                a: String,
+                b: String,
+            },
             C(bool, String),
         }
 
@@ -920,7 +923,9 @@ mod tests {
             A,
             B(bool),
             C(String, String),
-            D { a: String },
+            D {
+                a: String,
+            },
         }
         test_invalid_map_key(Enum::A);
         test_invalid_map_key(Enum::B(true));

--- a/crates/mp4/src/codec.rs
+++ b/crates/mp4/src/codec.rs
@@ -6,7 +6,11 @@ use scuffle_aac::AudioObjectType;
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub enum VideoCodec {
     /// <https://developer.mozilla.org/en-US/docs/Web/Media/Formats/codecs_parameter>
-    Avc { profile: u8, constraint_set: u8, level: u8 },
+    Avc {
+        profile: u8,
+        constraint_set: u8,
+        level: u8,
+    },
     /// There is barely any documentation on this.
     /// <https://hevcvideo.xp3.biz/html5_video.html>
     Hevc {
@@ -264,7 +268,9 @@ impl FromStr for VideoCodec {
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub enum AudioCodec {
-    Aac { object_type: AudioObjectType },
+    Aac {
+        object_type: AudioObjectType,
+    },
     Opus,
 }
 

--- a/crates/tinc/build/src/codegen/cel/compiler/mod.rs
+++ b/crates/tinc/build/src/codegen/cel/compiler/mod.rs
@@ -306,11 +306,20 @@ pub(crate) enum CompileError {
     #[error("not implemented")]
     NotImplemented,
     #[error("invalid syntax: {message} - {syntax}")]
-    InvalidSyntax { message: String, syntax: &'static str },
+    InvalidSyntax {
+        message: String,
+        syntax: &'static str,
+    },
     #[error("type conversion error on type {ty:?}: {message}")]
-    TypeConversion { ty: Box<CelType>, message: String },
+    TypeConversion {
+        ty: Box<CelType>,
+        message: String,
+    },
     #[error("member access error on type {ty:?}: {message}")]
-    MemberAccess { ty: Box<CelType>, message: String },
+    MemberAccess {
+        ty: Box<CelType>,
+        message: String,
+    },
     #[error("variable not found: {0}")]
     VariableNotFound(String),
     #[error("function not found: {0}")]

--- a/crates/tinc/cel/src/lib.rs
+++ b/crates/tinc/cel/src/lib.rs
@@ -38,11 +38,19 @@ pub enum CelError<'a> {
         op: &'static str,
     },
     #[error("bad unary operation: {op}{value}")]
-    BadUnaryOperation { op: &'static str, value: CelValue<'a> },
+    BadUnaryOperation {
+        op: &'static str,
+        value: CelValue<'a>,
+    },
     #[error("number out of range when performing {op}")]
-    NumberOutOfRange { op: &'static str },
+    NumberOutOfRange {
+        op: &'static str,
+    },
     #[error("bad access when trying to member {member} on {container}")]
-    BadAccess { member: CelValue<'a>, container: CelValue<'a> },
+    BadAccess {
+        member: CelValue<'a>,
+        container: CelValue<'a>,
+    },
 }
 
 #[derive(Clone, Debug)]

--- a/crates/tinc/src/private/error.rs
+++ b/crates/tinc/src/private/error.rs
@@ -294,7 +294,9 @@ pub enum TrackedErrorKind {
     DuplicateField,
     UnknownField,
     MissingField,
-    InvalidField { message: Box<str> },
+    InvalidField {
+        message: Box<str>,
+    },
 }
 
 #[derive(Debug)]

--- a/dev-tools/xtask/src/cmd/release/utils.rs
+++ b/dev-tools/xtask/src/cmd/release/utils.rs
@@ -41,7 +41,10 @@ struct GitReleaseMeta {
 #[derive(serde_derive::Deserialize, Debug, Clone)]
 #[serde(rename_all = "kebab-case", tag = "kind")]
 pub enum GitReleaseArtifact {
-    File { path: String, name: Option<String> },
+    File {
+        path: String,
+        name: Option<String>,
+    },
 }
 
 #[derive(serde_derive::Deserialize, Default, Debug, Clone)]

--- a/rustfmt.toml
+++ b/rustfmt.toml
@@ -7,3 +7,4 @@ style_edition = "2024"
 format_macro_matchers = true
 reorder_impl_items = true
 max_width = 125
+struct_variant_width = 0


### PR DESCRIPTION
Update the fmt style to always expand enum struct variants to be multi-line.

Reasoning: if I wanted a single line, I likely would have defined it as a tuple variant.
