### PR TITLE
disable sync-rdme job

### DIFF
--- a/.github/scripts/ci-matrix-prep.py
+++ b/.github/scripts/ci-matrix-prep.py
@@ -41,8 +41,10 @@ def is_fork_pr() -> bool:
         != "scufflecloud/scuffle".casefold()
     )
 
+
 def is_dispatch_or_cron() -> bool:
     return GITHUB_CONTEXT["event_name"] in ["workflow_dispatch", "schedule"]
+
 
 def pr_number() -> Optional[int]:
     if is_pr():
@@ -152,7 +154,9 @@ class Job:
 def create_docsrs_jobs() -> list[Job]:
     jobs: list[Job] = []
 
-    deploy_docs = not is_brawl("merge") and not is_fork_pr() and not is_dispatch_or_cron()
+    deploy_docs = (
+        not is_brawl("merge") and not is_fork_pr() and not is_dispatch_or_cron()
+    )
 
     jobs.append(
         Job(
@@ -296,7 +300,9 @@ def create_docsrs_jobs() -> list[Job]:
 def create_docusaurus_jobs() -> list[Job]:
     jobs: list[Job] = []
 
-    deploy_docs = not is_brawl("merge") and not is_fork_pr() and not is_dispatch_or_cron()
+    deploy_docs = (
+        not is_brawl("merge") and not is_fork_pr() and not is_dispatch_or_cron()
+    )
 
     jobs.append(
         Job(
@@ -768,7 +774,6 @@ def create_jobs() -> list[Job]:
         + create_hakari_jobs()
         + create_semver_checks_jobs()
         + create_docusaurus_jobs()
-        + create_readme_jobs()
     )
 
     return jobs


### PR DESCRIPTION
This pr disables the CI job for `cargo-sync-rdme` as it seems to be unmaintained, this will be fixed when the [Bazel implementation](https://github.com/ScuffleCloud/scuffle/pull/500) is merged