### PR TITLE
fix: editorconfig

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -14,10 +14,6 @@ trim_trailing_whitespace = true
 [*.md]
 trim_trailing_whitespace = false
 
-[*.yaml,*.yml]
+[*.yaml,*.yml,*.proto]
 indent_style = space
 indent_size = 2
-
-[*.proto]
-indent_style = space
-indent_size = 4


### PR DESCRIPTION
Sets the `indent_size` for `.proto` files to 2 since that is what the buf formatter does.
I would really prefer 4 spaces for visual clarity and consistency with other files but sadly the buf developers force everyone to use 2 spaces. (see https://github.com/bufbuild/buf/issues/2412)