### PR TITLE
feat(core): add project rpcs and types

### DIFF
--- a/cloud/core/src/cedar.rs
+++ b/cloud/core/src/cedar.rs
@@ -188,6 +188,10 @@ pub enum Action {
     ListOrganizationMembers,
     #[display("list_organizations_by_user")]
     ListOrganizationsByUser,
+    #[display("create_project")]
+    CreateProject,
+    #[display("list_project")]
+    ListProjects,
 
     // OrganizationInvitation related
     #[display("create_organization_invitation")]

--- a/cloud/core/src/models/organizations.rs
+++ b/cloud/core/src/models/organizations.rs
@@ -3,7 +3,6 @@ use std::sync::Arc;
 
 use diesel::Selectable;
 use diesel::prelude::{AsChangeset, Associations, Identifiable, Insertable, Queryable};
-use tinc::well_known::prost::Timestamp;
 
 use crate::cedar::CedarEntity;
 use crate::chrono_ext::ChronoDateTimeExt;
@@ -73,6 +72,17 @@ impl<G> CedarEntity<G> for Project {
 
     async fn parents(&self, _global: &Arc<G>) -> Result<HashSet<cedar_policy::EntityUid>, tonic::Status> {
         Ok(std::iter::once(CedarEntity::<G>::entity_uid(&self.organization_id)).collect())
+    }
+}
+
+impl From<Project> for pb::scufflecloud::core::v1::Project {
+    fn from(value: Project) -> Self {
+        Self {
+            id: value.id.to_string(),
+            name: value.name,
+            organization_id: value.organization_id.to_string(),
+            created_at: Some(tinc::well_known::prost::Timestamp::from(value.id.datetime())),
+        }
     }
 }
 
@@ -312,7 +322,7 @@ impl From<OrganizationInvitation> for pb::scufflecloud::core::v1::OrganizationIn
             email: value.email,
             invited_by_id: value.invited_by_id.to_string(),
             expires_at: value.expires_at.map(|dt| dt.to_prost_timestamp_utc()),
-            created_at: Some(Timestamp::from(value.id.datetime())),
+            created_at: Some(tinc::well_known::prost::Timestamp::from(value.id.datetime())),
         }
     }
 }

--- a/cloud/core/src/services/organizations.rs
+++ b/cloud/core/src/services/organizations.rs
@@ -38,4 +38,18 @@ impl<G: CoreConfig> pb::scufflecloud::core::v1::organizations_service_server::Or
     ) -> Result<tonic::Response<pb::scufflecloud::core::v1::OrganizationsList>, tonic::Status> {
         Operation::<G>::run(req).await.map(tonic::Response::new)
     }
+
+    async fn create_project(
+        &self,
+        req: tonic::Request<pb::scufflecloud::core::v1::CreateProjectRequest>,
+    ) -> Result<tonic::Response<pb::scufflecloud::core::v1::Project>, tonic::Status> {
+        Operation::<G>::run(req).await.map(tonic::Response::new)
+    }
+
+    async fn list_projects(
+        &self,
+        req: tonic::Request<pb::scufflecloud::core::v1::ListProjectsRequest>,
+    ) -> Result<tonic::Response<pb::scufflecloud::core::v1::ProjectsList>, tonic::Status> {
+        Operation::<G>::run(req).await.map(tonic::Response::new)
+    }
 }

--- a/cloud/core/static_policies.cedar
+++ b/cloud/core/static_policies.cedar
@@ -274,6 +274,22 @@ permit(
 
 permit(
     principal is User,
+    action == Action::"create_project",
+    resource is Organization
+) when {
+    principal in resource
+};
+
+permit(
+    principal is User,
+    action == Action::"list_projects",
+    resource is Organization
+) when {
+    principal in resource
+};
+
+permit(
+    principal is User,
     action == Action::"create_organization_invitation",
     resource is OrganizationInvitation
 ); // TODO: condition for owner

--- a/cloud/proto/pb/scufflecloud/core/v1/organizations.proto
+++ b/cloud/proto/pb/scufflecloud/core/v1/organizations.proto
@@ -33,3 +33,13 @@ message OrganizationInvitation {
   optional google.protobuf.Timestamp expires_at = 6;
   google.protobuf.Timestamp created_at = 7;
 }
+
+message Project {
+  string id = 1 [(string_constraint).id = true];
+  string name = 2 [(tinc.field).constraint.string = {
+    min_len: 1
+    max_len: 255
+  }];
+  string organization_id = 3 [(string_constraint).id = true];
+  google.protobuf.Timestamp created_at = 4;
+}

--- a/cloud/proto/pb/scufflecloud/core/v1/organizations_service.proto
+++ b/cloud/proto/pb/scufflecloud/core/v1/organizations_service.proto
@@ -25,6 +25,13 @@ service OrganizationsService {
   rpc ListOrganizationsByUser(ListOrganizationsByUserRequest) returns (OrganizationsList) {
     option (tinc.method).endpoint = {get: "/users/{id}/organizations"};
   }
+
+  rpc CreateProject(CreateProjectRequest) returns (Project) {
+    option (tinc.method).endpoint = {post: "/organizations/{id}/projects"};
+  }
+  rpc ListProjects(ListProjectsRequest) returns (ProjectsList) {
+    option (tinc.method).endpoint = {get: "/organizations/{id}/projects"};
+  }
 }
 
 message CreateOrganizationRequest {
@@ -72,4 +79,20 @@ message ListOrganizationMembersRequest {
 
 message OrganizationMembersList {
   repeated OrganizationMember members = 1;
+}
+
+message CreateProjectRequest {
+  string id = 1 [(string_constraint).id = true];
+  string name = 2 [(tinc.field).constraint.string = {
+    min_len: 1
+    max_len: 255
+  }];
+}
+
+message ListProjectsRequest {
+  string id = 1 [(string_constraint).id = true];
+}
+
+message ProjectsList {
+  repeated Project projects = 1;
 }


### PR DESCRIPTION
I need the `Project` type to improve the frontend auth logic, so here's a quick implementation of some basic endpoints that introduce it.