### PR TITLE
fix: dataloaders should get a copy of the pool

### DIFF
--- a/cloud/core/src/bin/standalone.rs
+++ b/cloud/core/src/bin/standalone.rs
@@ -300,12 +300,9 @@ impl scuffle_bootstrap::Global for Global {
             .await
             .context("build database pool")?;
 
-        let connection = database.get_owned().await.context("get database connection")?;
-        let user_loader = UserLoader::new(connection);
-        let connection = database.get_owned().await.context("get database connection")?;
-        let organization_loader = OrganizationLoader::new(connection);
-        let connection = database.get_owned().await.context("get database connection")?;
-        let organization_member_by_user_id_loader = OrganizationMemberByUserIdLoader::new(connection);
+        let user_loader = UserLoader::new(database.clone());
+        let organization_loader = OrganizationLoader::new(database.clone());
+        let organization_member_by_user_id_loader = OrganizationMemberByUserIdLoader::new(database.clone());
 
         let http_client = reqwest::Client::builder()
             .user_agent(&config.service_name)

--- a/cloud/core/src/dataloaders/users.rs
+++ b/cloud/core/src/dataloaders/users.rs
@@ -2,25 +2,31 @@ use std::collections::{HashMap, HashSet};
 use std::time::Duration;
 
 use diesel::{ExpressionMethods, QueryDsl, SelectableHelper};
-use diesel_async::pooled_connection::bb8::PooledConnection;
+use diesel_async::pooled_connection::bb8;
 use diesel_async::{AsyncPgConnection, RunQueryDsl};
 use scuffle_batching::{DataLoader, DataLoaderFetcher};
-use tokio::sync::Mutex;
 
 use crate::models::{User, UserId};
 use crate::schema::users;
 
-pub struct UserLoader(Mutex<PooledConnection<'static, AsyncPgConnection>>);
+pub struct UserLoader(bb8::Pool<AsyncPgConnection>);
 
 impl DataLoaderFetcher for UserLoader {
     type Key = UserId;
     type Value = User;
 
     async fn load(&self, keys: HashSet<Self::Key>) -> Option<HashMap<Self::Key, Self::Value>> {
+        let mut conn = self
+            .0
+            .get()
+            .await
+            .map_err(|e| tracing::error!(err = %e, "failed to get connection"))
+            .ok()?;
+
         let users = users::dsl::users
             .filter(users::dsl::id.eq_any(keys))
             .select(User::as_select())
-            .load::<User>(&mut self.0.lock().await)
+            .load::<User>(&mut conn)
             .await
             .map_err(|e| tracing::error!(err = %e, "failed to load users"))
             .ok()?;
@@ -30,7 +36,7 @@ impl DataLoaderFetcher for UserLoader {
 }
 
 impl UserLoader {
-    pub fn new(conn: PooledConnection<'static, AsyncPgConnection>) -> DataLoader<Self> {
-        DataLoader::new(Self(Mutex::new(conn)), 1000, 500, Duration::from_millis(5))
+    pub fn new(pool: bb8::Pool<AsyncPgConnection>) -> DataLoader<Self> {
+        DataLoader::new(Self(pool), 1000, 500, Duration::from_millis(5))
     }
 }


### PR DESCRIPTION
Dataloaders should get a copy of the pool so that they can run concurrently over a set of requests.