### PR TITLE
fix: cargo build and remove unused dependencies

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4819,7 +4819,6 @@ dependencies = [
  "camino",
  "clap",
  "env_logger 0.10.2",
- "fmtools",
  "log",
  "serde",
  "serde_derive",
@@ -4832,7 +4831,6 @@ version = "0.0.0"
 dependencies = [
  "camino",
  "clap",
- "quote",
  "rust_doctest_common",
  "serde",
  "serde_derive",
@@ -4846,7 +4844,6 @@ dependencies = [
  "camino",
  "serde",
  "serde_derive",
- "serde_json",
 ]
 
 [[package]]
@@ -4908,7 +4905,6 @@ name = "rustdoc_merger"
 version = "0.0.0"
 dependencies = [
  "camino",
- "camino-tempfile",
  "clap",
  "copy_dir",
  "lol_html",
@@ -5182,7 +5178,6 @@ checksum = "94143f37725109f92c262ed2cf5e59bce7498c01bcc1502d7b9afe439a4e9f49"
 name = "scuffle-aac"
 version = "0.1.4"
 dependencies = [
- "byteorder",
  "bytes",
  "document-features",
  "num-derive",
@@ -5302,7 +5297,6 @@ dependencies = [
 name = "scuffle-bytes-util"
 version = "0.1.5"
 dependencies = [
- "byteorder",
  "bytes",
  "bytestring",
  "document-features",
@@ -5391,7 +5385,6 @@ dependencies = [
  "insta",
  "libc",
  "nutype-enum",
- "rand 0.9.2",
  "rusty_ffmpeg",
  "scuffle-changelog",
  "scuffle-mp4",
@@ -5716,6 +5709,7 @@ dependencies = [
  "konst",
  "scufflecloud-core-db-types",
  "scufflecloud-core-traits",
+ "scufflecloud-ext-traits",
  "scufflecloud-proto",
  "serde",
  "serde_derive",
@@ -6484,13 +6478,11 @@ dependencies = [
  "pulldown-cmark-to-cmark",
  "regex",
  "rustdoc-types",
- "semver",
  "serde",
  "serde_derive",
  "serde_json",
  "sync_readme_common",
  "toml 0.9.5",
- "url",
 ]
 
 [[package]]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -5385,6 +5385,7 @@ dependencies = [
  "insta",
  "libc",
  "nutype-enum",
+ "rand 0.9.2",
  "rusty_ffmpeg",
  "scuffle-changelog",
  "scuffle-mp4",

--- a/changes.d/pr-610.toml
+++ b/changes.d/pr-610.toml
@@ -1,0 +1,19 @@
+[[scuffle-aac]]
+category = "fix"
+description = "remove unused dependency"
+authors = ["@lennartkloock"]
+
+[[scuffle-bytes-util]]
+category = "fix"
+description = "remove unused dependency"
+authors = ["@lennartkloock"]
+
+[[scuffle-ffmpeg]]
+category = "fix"
+description = "remove unused dependency"
+authors = ["@lennartkloock"]
+
+[[scuffle-flv]]
+category = "fix"
+description = "remove unused dependency"
+authors = ["@lennartkloock"]

--- a/cloud/core/cedar/Cargo.toml
+++ b/cloud/core/cedar/Cargo.toml
@@ -14,6 +14,7 @@ cedar-policy = "4.5"
 const_panic = "0.2"
 core-db-types = { path = "../db-types", package = "scufflecloud-core-db-types" }
 core-traits = { path = "../traits", package = "scufflecloud-core-traits" }
+ext-traits = { path = "../../ext-traits", package = "scufflecloud-ext-traits" }
 konst = { version = "0.4", features = ["iter"] }
 pb = { path = "../../proto", package = "scufflecloud-proto" }
 serde = "1"

--- a/cloud/core/emails/Cargo.toml
+++ b/cloud/core/emails/Cargo.toml
@@ -8,6 +8,9 @@ publish = false
 readme = "README.md"
 repository = "https://github.com/scufflecloud/scuffle"
 
+[lints.rust]
+unexpected_cfgs = { level = "warn", check-cfg = ['cfg(coverage_nightly)'] }
+
 [[bin]]
 name = "scufflecloud-core-emails-render-preview"
 path = "bin/render_preview.rs"

--- a/cloud/email/Cargo.toml
+++ b/cloud/email/Cargo.toml
@@ -33,7 +33,7 @@ rustls = { default-features = false, version = "0.23.31", features = ["aws_lc_rs
 scuffle-bootstrap = { path = "../../crates/bootstrap" }
 scuffle-bootstrap-telemetry = { features = ["opentelemetry-logs", "opentelemetry-traces"], path = "../../crates/bootstrap-telemetry" }
 scuffle-context = { path = "../../crates/context" }
-scuffle-http = { features = ["tracing"], path = "../../crates/http" }
+scuffle-http = { features = ["tracing", "tls-rustls"], path = "../../crates/http" }
 scuffle-settings = { features = ["all-formats", "bootstrap"], path = "../../crates/settings" }
 scuffle-signal = { features = ["bootstrap"], path = "../../crates/signal" }
 serde = "1.0.219"

--- a/cloud/ext-traits/Cargo.toml
+++ b/cloud/ext-traits/Cargo.toml
@@ -9,6 +9,9 @@ readme = "README.md"
 repository = "https://github.com/scufflecloud/scuffle"
 description = "Extension traits for Scuffle Cloud"
 
+[lints.rust]
+unexpected_cfgs = { level = "warn", check-cfg = ['cfg(coverage_nightly)'] }
+
 [dependencies]
 http = "1.3.1"
 tonic = "0.14.2"

--- a/crates/aac/Cargo.toml
+++ b/crates/aac/Cargo.toml
@@ -18,7 +18,6 @@ unexpected_cfgs = { level = "warn", check-cfg = ['cfg(coverage_nightly)'] }
 docs = ["dep:scuffle-changelog", "dep:document-features"]
 
 [dependencies]
-byteorder = "1.5"
 bytes = "1.5"
 document-features = { optional = true, version = "0.2" }
 num-derive = "0.4"

--- a/crates/bytes-util/Cargo.toml
+++ b/crates/bytes-util/Cargo.toml
@@ -14,7 +14,6 @@ description = "A utility crate for working with bytes."
 unexpected_cfgs = { level = "warn", check-cfg = ['cfg(coverage_nightly)'] }
 
 [dependencies]
-byteorder = "1.5.0"
 bytes = "1.5"
 bytestring = "1.4.0"
 document-features = { optional = true, version = "0.2" }

--- a/crates/ffmpeg/Cargo.toml
+++ b/crates/ffmpeg/Cargo.toml
@@ -22,7 +22,6 @@ crossbeam-channel = { optional = true, version = "0.5.13" }
 document-features = { optional = true, version = "0.2" }
 libc = "0.2"
 nutype-enum = { path = "../nutype-enum", version = "0.1.4" }
-rand = "0.9"
 rusty_ffmpeg = "0.16.4"
 scuffle-changelog = { optional = true, path = "../changelog", version = "0.1.0" }
 thiserror = "2.0"

--- a/crates/ffmpeg/Cargo.toml
+++ b/crates/ffmpeg/Cargo.toml
@@ -32,6 +32,7 @@ va_list = "0.2"
 [dev-dependencies]
 bytes = "1"
 insta = { features = ["filters"], version = "1.42" }
+rand = "0.9"
 scuffle-mp4 = { path = "../mp4" }
 sha2 = "0.10"
 tempfile = "3.15"

--- a/crates/flv/Cargo.toml
+++ b/crates/flv/Cargo.toml
@@ -29,7 +29,6 @@ thiserror = "2.0"
 
 document-features = { optional = true, version = "0.2" }
 nutype-enum = { path = "../nutype-enum", version = "0.1.4" }
-scuffle-aac = { path = "../aac", version = "0.1.3" }
 scuffle-amf0 = { features = ["serde"], path = "../amf0", version = "0.2.1" }
 scuffle-av1 = { path = "../av1", version = "0.1.3" }
 scuffle-bytes-util = { features = ["serde"], path = "../bytes-util", version = "0.1.3" }
@@ -39,6 +38,7 @@ scuffle-h265 = { path = "../h265", version = "0.2.1" }
 
 [dev-dependencies]
 insta = "1.42"
+scuffle-aac = { path = "../aac", version = "0.1.3" }
 
 [package.metadata.docs.rs]
 all-features = true

--- a/misc/utils/rust/analyzer/discover/Cargo.toml
+++ b/misc/utils/rust/analyzer/discover/Cargo.toml
@@ -13,7 +13,6 @@ anyhow = "1"
 camino = { version = "1", features = ["serde1"] }
 clap = { version = "4.5", features = ["derive", "env"] }
 env_logger = "0.10"
-fmtools = "0.1"
 log = "0.4"
 serde = "1"
 serde_derive = "1"

--- a/misc/utils/rust/doc/merger/Cargo.toml
+++ b/misc/utils/rust/doc/merger/Cargo.toml
@@ -6,7 +6,6 @@ publish = false
 
 [dependencies]
 camino = { version = "1", features = ["serde1"] }
-camino-tempfile = "1.4"
 clap = { version = "4.5", features = ["derive", "env"] }
 copy_dir = "0.1"
 lol_html = "2.6"

--- a/misc/utils/rust/doc/test/builder/Cargo.toml
+++ b/misc/utils/rust/doc/test/builder/Cargo.toml
@@ -7,7 +7,6 @@ publish = false
 [dependencies]
 camino = { version = "1", features = ["serde1"] }
 clap = { version = "4.5", features = ["derive", "env"] }
-quote = "1"
 rust_doctest_common.path = "../common"
 serde = "1"
 serde_derive = "1"

--- a/misc/utils/rust/doc/test/common/Cargo.toml
+++ b/misc/utils/rust/doc/test/common/Cargo.toml
@@ -8,7 +8,6 @@ publish = false
 camino = { version = "1", features = ["serde1"] }
 serde = "1"
 serde_derive = "1"
-serde_json = "1"
 
 [package.metadata.sync-readme.badges]
 license = true

--- a/misc/utils/rust/sync_readme/Cargo.toml
+++ b/misc/utils/rust/sync_readme/Cargo.toml
@@ -13,13 +13,11 @@ pulldown-cmark = "0.13"
 pulldown-cmark-to-cmark = "21"
 regex = "1"
 rustdoc-types = { version = "0.55", features = ["rustc-hash"] }
-semver = "1"
 serde = "1"
 serde_derive = "1"
 serde_json = "1"
 sync_readme_common.path = "common"
 toml = "0.9"
-url = "2"
 
 [package.metadata.sync-readme.badges]
 license = true

--- a/vendor/cargo/defs.bzl
+++ b/vendor/cargo/defs.bzl
@@ -1951,6 +1951,7 @@ _NORMAL_DEV_DEPENDENCIES = {
             _COMMON_CONDITION: {
                 "bytes": Label("@cargo_vendor//:bytes-1.10.1"),
                 "insta": Label("@cargo_vendor//:insta-1.43.2"),
+                "rand": Label("@cargo_vendor//:rand-0.9.2"),
                 "sha2": Label("@cargo_vendor//:sha2-0.10.9"),
                 "tempfile": Label("@cargo_vendor//:tempfile-3.22.0"),
                 "tracing-subscriber": Label("@cargo_vendor//:tracing-subscriber-0.3.20"),

--- a/vendor/cargo/defs.bzl
+++ b/vendor/cargo/defs.bzl
@@ -623,7 +623,6 @@ _NORMAL_DEPENDENCIES = {
     "crates/aac": {
         _REQUIRED_FEATURE: {
             _COMMON_CONDITION: {
-                "byteorder": Label("@cargo_vendor//:byteorder-1.5.0"),
                 "bytes": Label("@cargo_vendor//:bytes-1.10.1"),
                 "num-traits": Label("@cargo_vendor//:num-traits-0.2.19"),
             },
@@ -732,7 +731,6 @@ _NORMAL_DEPENDENCIES = {
     "crates/bytes-util": {
         _REQUIRED_FEATURE: {
             _COMMON_CONDITION: {
-                "byteorder": Label("@cargo_vendor//:byteorder-1.5.0"),
                 "bytes": Label("@cargo_vendor//:bytes-1.10.1"),
                 "bytestring": Label("@cargo_vendor//:bytestring-1.4.0"),
             },
@@ -803,7 +801,6 @@ _NORMAL_DEPENDENCIES = {
                 "arc-swap": Label("@cargo_vendor//:arc-swap-1.7.1"),
                 "bon": Label("@cargo_vendor//:bon-3.7.2"),
                 "libc": Label("@cargo_vendor//:libc-0.2.175"),
-                "rand": Label("@cargo_vendor//:rand-0.9.2"),
                 "rusty_ffmpeg": Label("@cargo_vendor//:rusty_ffmpeg-0.16.7+ffmpeg.8"),
                 "thiserror": Label("@cargo_vendor//:thiserror-2.0.16"),
                 "va_list": Label("@cargo_vendor//:va_list-0.2.1"),
@@ -1211,7 +1208,6 @@ _NORMAL_DEPENDENCIES = {
                 "camino": Label("@cargo_vendor//:camino-1.1.12"),
                 "clap": Label("@cargo_vendor//:clap-4.5.47"),
                 "env_logger": Label("@cargo_vendor//:env_logger-0.10.2"),
-                "fmtools": Label("@cargo_vendor//:fmtools-0.1.2"),
                 "log": Label("@cargo_vendor//:log-0.4.28"),
                 "serde": Label("@cargo_vendor//:serde-1.0.220"),
                 "serde_json": Label("@cargo_vendor//:serde_json-1.0.145"),
@@ -1232,7 +1228,6 @@ _NORMAL_DEPENDENCIES = {
         _REQUIRED_FEATURE: {
             _COMMON_CONDITION: {
                 "camino": Label("@cargo_vendor//:camino-1.1.12"),
-                "camino-tempfile": Label("@cargo_vendor//:camino-tempfile-1.4.1"),
                 "clap": Label("@cargo_vendor//:clap-4.5.47"),
                 "copy_dir": Label("@cargo_vendor//:copy_dir-0.1.3"),
                 "lol_html": Label("@cargo_vendor//:lol_html-2.6.0"),
@@ -1246,7 +1241,6 @@ _NORMAL_DEPENDENCIES = {
             _COMMON_CONDITION: {
                 "camino": Label("@cargo_vendor//:camino-1.1.12"),
                 "clap": Label("@cargo_vendor//:clap-4.5.47"),
-                "quote": Label("@cargo_vendor//:quote-1.0.40"),
                 "serde": Label("@cargo_vendor//:serde-1.0.220"),
                 "serde_json": Label("@cargo_vendor//:serde_json-1.0.145"),
             },
@@ -1257,7 +1251,6 @@ _NORMAL_DEPENDENCIES = {
             _COMMON_CONDITION: {
                 "camino": Label("@cargo_vendor//:camino-1.1.12"),
                 "serde": Label("@cargo_vendor//:serde-1.0.220"),
-                "serde_json": Label("@cargo_vendor//:serde_json-1.0.145"),
             },
         },
     },
@@ -1291,11 +1284,9 @@ _NORMAL_DEPENDENCIES = {
                 "pulldown-cmark-to-cmark": Label("@cargo_vendor//:pulldown-cmark-to-cmark-21.0.0"),
                 "regex": Label("@cargo_vendor//:regex-1.11.2"),
                 "rustdoc-types": Label("@cargo_vendor//:rustdoc-types-0.55.0"),
-                "semver": Label("@cargo_vendor//:semver-1.0.26"),
                 "serde": Label("@cargo_vendor//:serde-1.0.220"),
                 "serde_json": Label("@cargo_vendor//:serde_json-1.0.145"),
                 "toml": Label("@cargo_vendor//:toml-0.9.5"),
-                "url": Label("@cargo_vendor//:url-2.5.7"),
             },
         },
     },
@@ -4300,6 +4291,7 @@ _RESOLVED_FEATURE_FLAGS = {
     "crates/http": {
         _COMMON_CONDITION: [
             "default",
+            "tls-rustls",
             "tracing",
         ],
     },


### PR DESCRIPTION
This PR fixes the normal cargo build and removes unused dependencies that I found using [cargo-udeps](https://github.com/est31/cargo-udeps).