### PR TITLE
fix(core): google login for non-google users

### DIFF
--- a/cloud/core/src/common.rs
+++ b/cloud/core/src/common.rs
@@ -10,10 +10,7 @@ use core_db_types::schema::{
     user_emails, user_sessions, users,
 };
 use core_traits::EmailServiceClient;
-use diesel::{
-    BoolExpressionMethods, ExpressionMethods, JoinOnDsl, NullableExpressionMethods, OptionalExtension, QueryDsl,
-    SelectableHelper,
-};
+use diesel::{BoolExpressionMethods, ExpressionMethods, JoinOnDsl, OptionalExtension, QueryDsl, SelectableHelper};
 use diesel_async::RunQueryDsl;
 use ext_traits::{DisplayExt, OptionExt, ResultExt};
 use geo_ip::maxminddb;
@@ -119,7 +116,7 @@ pub(crate) async fn get_user_by_email(
     email: &str,
 ) -> Result<Option<User>, tonic::Status> {
     let user = users::dsl::users
-        .inner_join(user_emails::dsl::user_emails.on(users::dsl::primary_email.eq(user_emails::dsl::email.nullable())))
+        .inner_join(user_emails::dsl::user_emails.on(users::dsl::id.eq(user_emails::dsl::user_id)))
         .filter(user_emails::dsl::email.eq(&email))
         .select(User::as_select())
         .first::<User>(db)

--- a/cloud/core/src/services.rs
+++ b/cloud/core/src/services.rs
@@ -50,6 +50,7 @@ fn grpc_web_cors_layer() -> CorsLayer {
     let expose_headers = [
         HeaderName::from_static("grpc-encoding"),
         HeaderName::from_static("grpc-status"),
+        HeaderName::from_static("grpc-status-details-bin"),
         HeaderName::from_static("grpc-message"),
     ];
 


### PR DESCRIPTION
This PR fixes the Google login for emails that are already registered with us but not associated with a Google account yet. When someone logs in with a Google account which is not linked to a Scuffle user and whose email matches one that is already on record, the Google account will get linked to that existing account now.