### PR TITLE
feat(core): dashboard origin from request

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -6059,6 +6059,7 @@ dependencies = [
  "tonic",
  "tonic-types",
  "tracing",
+ "url",
 ]
 
 [[package]]

--- a/cloud/core/bin/standalone/config.rs
+++ b/cloud/core/bin/standalone/config.rs
@@ -4,6 +4,25 @@ use std::path::PathBuf;
 use anyhow::Context;
 use fred::prelude::ClientLike;
 
+#[derive(serde_derive::Deserialize, smart_default::SmartDefault, Debug, Clone)]
+#[serde(rename_all = "snake_case", tag = "type", content = "url")]
+pub enum DashboardOrigin {
+    #[default]
+    Static(
+        #[default("https://dashboard.scuffle.cloud".parse().unwrap())]
+        url::Url,
+    ),
+    FromRequest,
+}
+
+#[derive(serde_derive::Deserialize, smart_default::SmartDefault, Debug, Clone)]
+pub struct WebauthnConfig {
+    #[default = "scuffle.cloud"]
+    pub rp_id: String,
+    #[default("https://dashboard.scuffle.cloud".parse().unwrap())]
+    pub rp_origin: url::Url,
+}
+
 const fn days(days: u64) -> std::time::Duration {
     hours(days * 24)
 }

--- a/cloud/core/src/common.rs
+++ b/cloud/core/src/common.rs
@@ -252,6 +252,7 @@ pub(crate) async fn mfa_options(
 pub(crate) async fn create_session<G: core_traits::Global>(
     global: &Arc<G>,
     tx: &mut impl diesel_async::AsyncConnection<Backend = diesel::pg::Pg>,
+    dashboard_origin: &url::Url,
     user: &User,
     device: pb::scufflecloud::core::v1::Device,
     ip_info: &IpAddressInfo,
@@ -322,7 +323,7 @@ pub(crate) async fn create_session<G: core_traits::Global>(
             .into_tonic_internal_err("failed to lookup geoip info")?
             .map(Into::into)
             .unwrap_or_default();
-        let email = core_emails::new_device_email(global.dashboard_origin(), ip_info.ip_address, geo_info)
+        let email = core_emails::new_device_email(dashboard_origin, ip_info.ip_address, geo_info)
             .into_tonic_internal_err("failed to render email")?;
         let email = email_to_pb(global, primary_email.clone(), user.preferred_name.clone(), email);
 

--- a/cloud/core/src/google_api.rs
+++ b/cloud/core/src/google_api.rs
@@ -56,21 +56,26 @@ pub(crate) enum GoogleTokenError {
     RequestFailed(#[from] reqwest::Error),
 }
 
-fn redirect_uri<G: core_traits::Global>(global: &Arc<G>) -> String {
-    global.dashboard_origin().join("/oauth2-callback/google").unwrap().to_string()
+fn redirect_uri(dashboard_origin: &url::Url) -> String {
+    dashboard_origin.join("/oauth2-callback/google").unwrap().to_string()
 }
 
-pub(crate) fn authorization_url<G: core_traits::Global>(global: &Arc<G>, state: &str) -> String {
+pub(crate) fn authorization_url<G: core_traits::Global>(
+    global: &Arc<G>,
+    dashboard_origin: &url::Url,
+    state: &str,
+) -> String {
     format!(
         "https://accounts.google.com/o/oauth2/v2/auth?client_id={}&redirect_uri={}&response_type=code&scope={}&state={state}",
         global.google_oauth2_config().client_id,
-        urlencoding::encode(&redirect_uri(global)),
+        urlencoding::encode(&redirect_uri(dashboard_origin)),
         ALL_SCOPES.join("%20"), // URL-encoded space
     )
 }
 
 pub(crate) async fn request_tokens<G: core_traits::Global>(
     global: &Arc<G>,
+    dashboard_origin: &url::Url,
     code: &str,
 ) -> Result<GoogleToken, GoogleTokenError> {
     let tokens: GoogleToken = global
@@ -81,7 +86,7 @@ pub(crate) async fn request_tokens<G: core_traits::Global>(
             ("client_secret", global.google_oauth2_config().client_secret.as_ref()),
             ("code", code),
             ("grant_type", "authorization_code"),
-            ("redirect_uri", &redirect_uri(global)),
+            ("redirect_uri", &redirect_uri(dashboard_origin)),
         ])
         .send()
         .await?

--- a/cloud/core/src/http_ext.rs
+++ b/cloud/core/src/http_ext.rs
@@ -22,6 +22,14 @@ pub(crate) trait CoreRequestExt: ext_traits::RequestExt {
             ErrorDetails::new(),
         )
     }
+
+    fn dashboard_origin<G: core_traits::ConfigInterface + 'static>(&self) -> Result<url::Url, tonic::Status> {
+        self.global::<G>()?
+            .dashboard_origin()
+            .cloned()
+            .or_else(|| self.origin())
+            .ok_or_else(|| tonic::Status::invalid_argument("missing origin header and no dashboard origin configured"))
+    }
 }
 
 impl<T> CoreRequestExt for T where T: ext_traits::RequestExt {}

--- a/cloud/core/src/operations/user_session_requests.rs
+++ b/cloud/core/src/operations/user_session_requests.rs
@@ -265,6 +265,7 @@ impl<G: core_traits::Global> Operation<G> for tonic::Request<pb::scufflecloud::c
     ) -> Result<Self::Response, tonic::Status> {
         let global = &self.global::<G>()?;
         let ip_info = self.ip_address_info()?;
+        let dashboard_origin = self.dashboard_origin::<G>()?;
         let payload = self.into_inner();
 
         let device = payload.device.require("device")?;
@@ -280,7 +281,8 @@ impl<G: core_traits::Global> Operation<G> for tonic::Request<pb::scufflecloud::c
 
         let conn = driver.conn().await?;
 
-        let new_token = common::create_session(global, conn, &approved_by, device, &ip_info, false).await?;
+        let new_token =
+            common::create_session(global, conn, &dashboard_origin, &approved_by, device, &ip_info, false).await?;
         Ok(new_token)
     }
 }

--- a/cloud/core/src/operations/users.rs
+++ b/cloud/core/src/operations/users.rs
@@ -278,7 +278,7 @@ impl<G: core_traits::Global> Operation<G> for tonic::Request<pb::scufflecloud::c
             .into_tonic_internal_err("failed to insert email registration request")?;
 
         // Send email
-        let email = core_emails::add_new_email_email(global.dashboard_origin(), code_base64, timeout)
+        let email = core_emails::add_new_email_email(&self.dashboard_origin::<G>()?, code_base64, timeout)
             .into_tonic_internal_err("failed to render add new email email")?;
         let email = common::email_to_pb(global, resource.email.clone(), user.preferred_name, email);
 

--- a/cloud/core/traits/src/config.rs
+++ b/cloud/core/traits/src/config.rs
@@ -6,7 +6,7 @@ pub trait ConfigInterface: Send + Sync {
     fn turnstile_secret_key(&self) -> &str;
     fn email_from_name(&self) -> &str;
     fn email_from_address(&self) -> &str;
-    fn dashboard_origin(&self) -> &url::Url;
+    fn dashboard_origin(&self) -> Option<&url::Url>;
     fn timeout_config(&self) -> TimeoutConfig;
     fn google_oauth2_config(&self) -> GoogleOAuth2Config<'_>;
 }

--- a/cloud/ext-traits/Cargo.toml
+++ b/cloud/ext-traits/Cargo.toml
@@ -17,6 +17,7 @@ http = "1.3.1"
 tonic = "0.14.2"
 tonic-types = "0.14.2"
 tracing = "0.1.41"
+url = "2.5"
 
 [package.metadata.sync-readme.badges]
 docs-rs = false

--- a/cloud/ext-traits/src/http_ext.rs
+++ b/cloud/ext-traits/src/http_ext.rs
@@ -11,11 +11,17 @@ pub trait RequestExt {
             .map(Arc::clone)
             .into_tonic_internal_err("missing global extension")
     }
+
+    fn origin(&self) -> Option<url::Url>;
 }
 
 impl<T> RequestExt for tonic::Request<T> {
     fn extensions(&self) -> &http::Extensions {
         self.extensions()
+    }
+
+    fn origin(&self) -> Option<url::Url> {
+        self.metadata().get("origin")?.to_str().ok()?.parse().ok()
     }
 }
 
@@ -23,10 +29,18 @@ impl RequestExt for tonic::Extensions {
     fn extensions(&self) -> &http::Extensions {
         self
     }
+
+    fn origin(&self) -> Option<url::Url> {
+        None
+    }
 }
 
 impl<T> RequestExt for http::Request<T> {
     fn extensions(&self) -> &http::Extensions {
         self.extensions()
+    }
+
+    fn origin(&self) -> Option<url::Url> {
+        self.headers().get("origin")?.to_str().ok()?.parse().ok()
     }
 }

--- a/vendor/cargo/defs.bzl
+++ b/vendor/cargo/defs.bzl
@@ -582,6 +582,7 @@ _NORMAL_DEPENDENCIES = {
                 "tonic": Label("@cargo_vendor//:tonic-0.14.2"),
                 "tonic-types": Label("@cargo_vendor//:tonic-types-0.14.2"),
                 "tracing": Label("@cargo_vendor//:tracing-0.1.41"),
+                "url": Label("@cargo_vendor//:url-2.5.7"),
             },
         },
     },


### PR DESCRIPTION
This PR adds the ability for the core service to take the dashboard origin from the request `Origin` header instead a static config value. This has the advantage that the server can be used with any frontend independent of its URL.