### PR TITLE
bump rules_img

### DIFF
--- a/misc/toolchains/docker.MODULE.bazel
+++ b/misc/toolchains/docker.MODULE.bazel
@@ -1,16 +1,26 @@
+commit = "f70af24d5bc85eff66e18377c6e02d08e69d9433"
+
 bazel_dep(name = "rules_img")
-archive_override(
+git_override(
     module_name = "rules_img",
-    sha256 = "0e7a69e8a0f453b28e384f4483b7e47ab91ac6ae9a312924e6467ea50daefa97",
-    urls = ["https://github.com/bazel-contrib/rules_img/releases/download/v0.2.5/rules_img-v0.2.5.tar.gz"],
+    remote = "https://github.com/bazel-contrib/rules_img.git",
+    commit = commit,
 )
 
 bazel_dep(name = "rules_img_tool")
 git_override(
     module_name = "rules_img_tool",
-    commit = "f97821e8103f08d08873fd6c72eae7a096197488",
     remote = "https://github.com/bazel-contrib/rules_img.git",
-    strip_prefix = "img_tool/",
+    strip_prefix = "img_tool",
+    commit = commit,
+)
+
+bazel_dep(name = "rules_img_pull_tool")
+git_override(
+    module_name = "rules_img_pull_tool",
+    remote = "https://github.com/bazel-contrib/rules_img.git",
+    strip_prefix = "pull_tool",
+    commit = commit,
 )
 
 register_toolchains("@rules_img_tool//toolchain:all")


### PR DESCRIPTION
I have been working with the https://github.com/bazel-contrib/rules_img/issues/110 maintainer to try make it easier to use and to accommodate our usecase. Currently we use `rules_img` to pull a postgres image and run a docker container during a build step so that we can perform and validate database migrations.

This commit simplifies the build from the rules_img. 