### PR TITLE
chore: update testcontainers

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -210,6 +210,22 @@ dependencies = [
 ]
 
 [[package]]
+name = "astral-tokio-tar"
+version = "0.5.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ec179a06c1769b1e42e1e2cbe74c7dcdb3d6383c838454d063eaac5bbb7ebbe5"
+dependencies = [
+ "filetime",
+ "futures-core",
+ "libc",
+ "portable-atomic",
+ "rustc-hash",
+ "tokio",
+ "tokio-stream",
+ "xattr",
+]
+
+[[package]]
 name = "async-scoped"
 version = "0.9.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3183,7 +3199,7 @@ checksum = "391290121bad3d37fbddad76d8f5d1c1c314cfc646d143d7e07a3086ddff0ce3"
 dependencies = [
  "bitflags 2.9.4",
  "libc",
- "redox_syscall 0.5.17",
+ "redox_syscall",
 ]
 
 [[package]]
@@ -3992,7 +4008,7 @@ checksum = "bc838d2a56b5b1a6c25f55575dfc605fabb63bb2365f6c2353ef9159aa69e4a5"
 dependencies = [
  "cfg-if",
  "libc",
- "redox_syscall 0.5.17",
+ "redox_syscall",
  "smallvec",
  "windows-targets 0.52.6",
 ]
@@ -4874,15 +4890,6 @@ dependencies = [
 
 [[package]]
 name = "redox_syscall"
-version = "0.3.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "567664f262709473930a4bf9e51bf2ebf3348f2e748ccc50dea20646858f8f29"
-dependencies = [
- "bitflags 1.3.2",
-]
-
-[[package]]
-name = "redox_syscall"
 version = "0.5.17"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5407465600fb0548f1442edf71dd20683c6ed326200ace4b1ef0763521bb3b77"
@@ -5279,6 +5286,7 @@ dependencies = [
  "aws-lc-rs",
  "log",
  "once_cell",
+ "ring",
  "rustls-pki-types",
  "rustls-webpki",
  "subtle",
@@ -7025,9 +7033,11 @@ dependencies = [
 
 [[package]]
 name = "testcontainers"
-version = "0.25.0"
-source = "git+https://github.com/testcontainers/testcontainers-rs.git?rev=6d8e248a5637a3bb8ac0bb390717f6c327ffbad1#6d8e248a5637a3bb8ac0bb390717f6c327ffbad1"
+version = "0.25.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3f3ac71069f20ecfa60c396316c283fbf35e6833a53dff551a31b5458da05edc"
 dependencies = [
+ "astral-tokio-tar",
  "async-trait",
  "bollard",
  "bytes",
@@ -7045,7 +7055,6 @@ dependencies = [
  "thiserror 2.0.16",
  "tokio",
  "tokio-stream",
- "tokio-tar",
  "tokio-util",
  "ulid",
  "url",
@@ -7381,21 +7390,6 @@ dependencies = [
  "pin-project-lite",
  "tokio",
  "tokio-util",
-]
-
-[[package]]
-name = "tokio-tar"
-version = "0.3.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9d5714c010ca3e5c27114c1cdeb9d14641ace49874aa5626d7149e47aedace75"
-dependencies = [
- "filetime",
- "futures-core",
- "libc",
- "redox_syscall 0.3.5",
- "tokio",
- "tokio-stream",
- "xattr",
 ]
 
 [[package]]
@@ -8949,3 +8943,9 @@ dependencies = [
  "cc",
  "pkg-config",
 ]
+
+[[patch.unused]]
+name = "testcontainers"
+version = "0.25.0"
+source = "git+https://github.com/testcontainers/testcontainers-rs.git?rev=6d8e248a5637a3bb8ac0bb390717f6c327ffbad1#6d8e248a5637a3bb8ac0bb390717f6c327ffbad1"
+

--- a/misc/toolchains/rust.MODULE.bazel
+++ b/misc/toolchains/rust.MODULE.bazel
@@ -305,7 +305,7 @@ use_repo(
     "cargo_vendor__target-spec-3.5.2",
     "cargo_vendor__target-triple-0.1.4",
     "cargo_vendor__tempfile-3.22.0",
-    "cargo_vendor__testcontainers-0.25.0",
+    "cargo_vendor__testcontainers-0.25.2",
     "cargo_vendor__thiserror-2.0.16",
     "cargo_vendor__tokio-1.47.1",
     "cargo_vendor__tokio-rustls-0.26.2",

--- a/vendor/cargo/BUILD.astral-tokio-tar-0.5.6.bazel
+++ b/vendor/cargo/BUILD.astral-tokio-tar-0.5.6.bazel
@@ -39,7 +39,7 @@ rust_library(
         "xattr",
     ],
     crate_root = "src/lib.rs",
-    edition = "2018",
+    edition = "2021",
     rustc_env_files = [
         ":cargo_toml_env_vars",
     ],
@@ -48,7 +48,7 @@ rust_library(
     ],
     tags = [
         "cargo-bazel",
-        "crate-name=tokio-tar",
+        "crate-name=astral-tokio-tar",
         "manual",
         "noclippy",
         "norustfmt",
@@ -63,10 +63,12 @@ rust_library(
         "@rules_rust//rust/platform:x86_64-unknown-linux-gnu": [],
         "//conditions:default": ["@platforms//:incompatible"],
     }),
-    version = "0.3.1",
+    version = "0.5.6",
     deps = [
         "@cargo_vendor__filetime-0.2.26//:filetime",
         "@cargo_vendor__futures-core-0.3.31//:futures_core",
+        "@cargo_vendor__portable-atomic-1.11.1//:portable_atomic",
+        "@cargo_vendor__rustc-hash-2.1.1//:rustc_hash",
         "@cargo_vendor__tokio-1.47.1//:tokio",
         "@cargo_vendor__tokio-stream-0.1.17//:tokio_stream",
     ] + select({

--- a/vendor/cargo/BUILD.bazel
+++ b/vendor/cargo/BUILD.bazel
@@ -1594,14 +1594,14 @@ transition_alias_opt(
 )
 
 transition_alias_opt(
-    name = "testcontainers-0.25.0",
-    actual = "@cargo_vendor__testcontainers-0.25.0//:testcontainers",
+    name = "testcontainers-0.25.2",
+    actual = "@cargo_vendor__testcontainers-0.25.2//:testcontainers",
     tags = ["manual"],
 )
 
 transition_alias_opt(
     name = "testcontainers",
-    actual = "@cargo_vendor__testcontainers-0.25.0//:testcontainers",
+    actual = "@cargo_vendor__testcontainers-0.25.2//:testcontainers",
     tags = ["manual"],
 )
 

--- a/vendor/cargo/BUILD.bollard-0.19.3.bazel
+++ b/vendor/cargo/BUILD.bollard-0.19.3.bazel
@@ -37,6 +37,7 @@ rust_library(
     crate_features = [
         "aws-lc-rs",
         "bollard-buildkit-proto",
+        "buildkit",
         "buildkit_providerless",
         "chrono",
         "default",
@@ -53,6 +54,7 @@ rust_library(
         "rustls-native-certs",
         "rustls-pemfile",
         "rustls-pki-types",
+        "ssl",
         "ssl_providerless",
         "tokio-stream",
         "tonic",

--- a/vendor/cargo/BUILD.ring-0.17.14.bazel
+++ b/vendor/cargo/BUILD.ring-0.17.14.bazel
@@ -42,8 +42,12 @@ rust_library(
         "alloc",
         "default",
         "dev_urandom_fallback",
-        "wasm32_unknown_unknown_js",
-    ],
+    ] + select({
+        "@rules_rust//rust/platform:wasm32-unknown-unknown": [
+            "wasm32_unknown_unknown_js",
+        ],
+        "//conditions:default": [],
+    }),
     crate_root = "src/lib.rs",
     edition = "2021",
     rustc_env_files = [
@@ -60,7 +64,13 @@ rust_library(
         "norustfmt",
     ],
     target_compatible_with = select({
+        "@rules_rust//rust/platform:aarch64-apple-darwin": [],
+        "@rules_rust//rust/platform:aarch64-pc-windows-msvc": [],
+        "@rules_rust//rust/platform:aarch64-unknown-linux-gnu": [],
         "@rules_rust//rust/platform:wasm32-unknown-unknown": [],
+        "@rules_rust//rust/platform:x86_64-apple-darwin": [],
+        "@rules_rust//rust/platform:x86_64-pc-windows-msvc": [],
+        "@rules_rust//rust/platform:x86_64-unknown-linux-gnu": [],
         "//conditions:default": ["@platforms//:incompatible"],
     }),
     version = "0.17.14",
@@ -69,7 +79,18 @@ rust_library(
         "@cargo_vendor__getrandom-0.2.16//:getrandom",
         "@cargo_vendor__ring-0.17.14//:build_script_build",
         "@cargo_vendor__untrusted-0.9.0//:untrusted",
-    ],
+    ] + select({
+        "@rules_rust//rust/platform:aarch64-apple-darwin": [
+            "@cargo_vendor__libc-0.2.175//:libc",  # cfg(all(all(target_arch = "aarch64", target_endian = "little"), target_vendor = "apple", any(target_os = "ios", target_os = "macos", target_os = "tvos", target_os = "visionos", target_os = "watchos")))
+        ],
+        "@rules_rust//rust/platform:aarch64-pc-windows-msvc": [
+            "@cargo_vendor__windows-sys-0.52.0//:windows_sys",  # cfg(all(all(target_arch = "aarch64", target_endian = "little"), target_os = "windows"))
+        ],
+        "@rules_rust//rust/platform:aarch64-unknown-linux-gnu": [
+            "@cargo_vendor__libc-0.2.175//:libc",  # cfg(all(any(all(target_arch = "aarch64", target_endian = "little"), all(target_arch = "arm", target_endian = "little")), any(target_os = "android", target_os = "linux")))
+        ],
+        "//conditions:default": [],
+    }),
 )
 
 cargo_build_script(
@@ -95,8 +116,12 @@ cargo_build_script(
         "alloc",
         "default",
         "dev_urandom_fallback",
-        "wasm32_unknown_unknown_js",
-    ],
+    ] + select({
+        "@rules_rust//rust/platform:wasm32-unknown-unknown": [
+            "wasm32_unknown_unknown_js",
+        ],
+        "//conditions:default": [],
+    }),
     crate_name = "build_script_build",
     crate_root = "build.rs",
     data = glob(

--- a/vendor/cargo/BUILD.rustls-0.23.32.bazel
+++ b/vendor/cargo/BUILD.rustls-0.23.32.bazel
@@ -49,6 +49,7 @@ rust_library(
         "log",
         "logging",
         "prefer-post-quantum",
+        "ring",
         "std",
         "tls12",
     ],
@@ -82,6 +83,7 @@ rust_library(
         "@cargo_vendor__aws-lc-rs-1.14.0//:aws_lc_rs",
         "@cargo_vendor__log-0.4.28//:log",
         "@cargo_vendor__once_cell-1.21.3//:once_cell",
+        "@cargo_vendor__ring-0.17.14//:ring",
         "@cargo_vendor__rustls-0.23.32//:build_script_build",
         "@cargo_vendor__rustls-pki-types-1.12.0//:rustls_pki_types",
         "@cargo_vendor__rustls-webpki-0.103.5//:webpki",
@@ -116,6 +118,7 @@ cargo_build_script(
         "log",
         "logging",
         "prefer-post-quantum",
+        "ring",
         "std",
         "tls12",
     ],
@@ -136,6 +139,7 @@ cargo_build_script(
     edition = "2021",
     link_deps = [
         "@cargo_vendor__aws-lc-rs-1.14.0//:aws_lc_rs",
+        "@cargo_vendor__ring-0.17.14//:ring",
     ],
     pkg_name = "rustls",
     rustc_env_files = [

--- a/vendor/cargo/BUILD.rustls-webpki-0.103.5.bazel
+++ b/vendor/cargo/BUILD.rustls-webpki-0.103.5.bazel
@@ -40,6 +40,7 @@ rust_library(
     crate_features = [
         "alloc",
         "aws-lc-rs",
+        "ring",
         "std",
     ],
     crate_root = "src/lib.rs",
@@ -70,6 +71,7 @@ rust_library(
     version = "0.103.5",
     deps = [
         "@cargo_vendor__aws-lc-rs-1.14.0//:aws_lc_rs",
+        "@cargo_vendor__ring-0.17.14//:ring",
         "@cargo_vendor__rustls-pki-types-1.12.0//:rustls_pki_types",
         "@cargo_vendor__untrusted-0.9.0//:untrusted",
     ],

--- a/vendor/cargo/BUILD.testcontainers-0.25.2.bazel
+++ b/vendor/cargo/BUILD.testcontainers-0.25.2.bazel
@@ -65,8 +65,9 @@ rust_library(
         "@rules_rust//rust/platform:x86_64-unknown-linux-gnu": [],
         "//conditions:default": ["@platforms//:incompatible"],
     }),
-    version = "0.25.0",
+    version = "0.25.2",
     deps = [
+        "@cargo_vendor__astral-tokio-tar-0.5.6//:tokio_tar",
         "@cargo_vendor__bollard-0.19.3//:bollard",
         "@cargo_vendor__bytes-1.10.1//:bytes",
         "@cargo_vendor__docker_credential-1.3.2//:docker_credential",
@@ -83,7 +84,6 @@ rust_library(
         "@cargo_vendor__thiserror-2.0.16//:thiserror",
         "@cargo_vendor__tokio-1.47.1//:tokio",
         "@cargo_vendor__tokio-stream-0.1.17//:tokio_stream",
-        "@cargo_vendor__tokio-tar-0.3.1//:tokio_tar",
         "@cargo_vendor__tokio-util-0.7.16//:tokio_util",
         "@cargo_vendor__ulid-1.2.1//:ulid",
         "@cargo_vendor__url-2.5.7//:url",

--- a/vendor/cargo/defs.bzl
+++ b/vendor/cargo/defs.bzl
@@ -1290,7 +1290,7 @@ _NORMAL_DEPENDENCIES = {
                 "log": Label("@cargo_vendor//:log-0.4.28"),
                 "serde": Label("@cargo_vendor//:serde-1.0.228"),
                 "serde_json": Label("@cargo_vendor//:serde_json-1.0.145"),
-                "testcontainers": Label("@cargo_vendor//:testcontainers-0.25.0"),
+                "testcontainers": Label("@cargo_vendor//:testcontainers-0.25.2"),
                 "tokio": Label("@cargo_vendor//:tokio-1.47.1"),
             },
         },
@@ -4823,6 +4823,9 @@ _CONDITIONS = {
     "aarch64-apple-darwin": ["@rules_rust//rust/platform:aarch64-apple-darwin"],
     "aarch64-pc-windows-msvc": ["@rules_rust//rust/platform:aarch64-pc-windows-msvc"],
     "aarch64-unknown-linux-gnu": ["@rules_rust//rust/platform:aarch64-unknown-linux-gnu"],
+    "cfg(all(all(target_arch = \"aarch64\", target_endian = \"little\"), target_os = \"windows\"))": ["@rules_rust//rust/platform:aarch64-pc-windows-msvc"],
+    "cfg(all(all(target_arch = \"aarch64\", target_endian = \"little\"), target_vendor = \"apple\", any(target_os = \"ios\", target_os = \"macos\", target_os = \"tvos\", target_os = \"visionos\", target_os = \"watchos\")))": ["@rules_rust//rust/platform:aarch64-apple-darwin"],
+    "cfg(all(any(all(target_arch = \"aarch64\", target_endian = \"little\"), all(target_arch = \"arm\", target_endian = \"little\")), any(target_os = \"android\", target_os = \"linux\")))": ["@rules_rust//rust/platform:aarch64-unknown-linux-gnu"],
     "cfg(all(any(target_arch = \"wasm32\", target_arch = \"wasm64\"), target_os = \"unknown\"))": ["@rules_rust//rust/platform:wasm32-unknown-unknown"],
     "cfg(all(any(target_arch = \"x86_64\", target_arch = \"arm64ec\"), target_env = \"msvc\", not(windows_raw_dylib)))": ["@rules_rust//rust/platform:x86_64-pc-windows-msvc"],
     "cfg(all(any(target_os = \"linux\", target_os = \"android\"), not(any(all(target_os = \"linux\", target_env = \"\"), getrandom_backend = \"custom\", getrandom_backend = \"linux_raw\", getrandom_backend = \"rdrand\", getrandom_backend = \"rndr\"))))": ["@rules_rust//rust/platform:aarch64-unknown-linux-gnu", "@rules_rust//rust/platform:x86_64-unknown-linux-gnu"],
@@ -5097,6 +5100,16 @@ def crate_repositories():
         urls = ["https://static.crates.io/crates/asn1-rs-impl/0.2.0/download"],
         strip_prefix = "asn1-rs-impl-0.2.0",
         build_file = Label("//vendor/cargo:BUILD.asn1-rs-impl-0.2.0.bazel"),
+    )
+
+    maybe(
+        http_archive,
+        name = "cargo_vendor__astral-tokio-tar-0.5.6",
+        sha256 = "ec179a06c1769b1e42e1e2cbe74c7dcdb3d6383c838454d063eaac5bbb7ebbe5",
+        type = "tar.gz",
+        urls = ["https://static.crates.io/crates/astral-tokio-tar/0.5.6/download"],
+        strip_prefix = "astral-tokio-tar-0.5.6",
+        build_file = Label("//vendor/cargo:BUILD.astral-tokio-tar-0.5.6.bazel"),
     )
 
     maybe(
@@ -10389,13 +10402,13 @@ def crate_repositories():
     )
 
     maybe(
-        new_git_repository,
-        name = "cargo_vendor__testcontainers-0.25.0",
-        commit = "6d8e248a5637a3bb8ac0bb390717f6c327ffbad1",
-        init_submodules = True,
-        remote = "https://github.com/testcontainers/testcontainers-rs.git",
-        build_file = Label("//vendor/cargo:BUILD.testcontainers-0.25.0.bazel"),
-        strip_prefix = "testcontainers",
+        http_archive,
+        name = "cargo_vendor__testcontainers-0.25.2",
+        sha256 = "3f3ac71069f20ecfa60c396316c283fbf35e6833a53dff551a31b5458da05edc",
+        type = "tar.gz",
+        urls = ["https://static.crates.io/crates/testcontainers/0.25.2/download"],
+        strip_prefix = "testcontainers-0.25.2",
+        build_file = Label("//vendor/cargo:BUILD.testcontainers-0.25.2.bazel"),
     )
 
     maybe(
@@ -10576,16 +10589,6 @@ def crate_repositories():
         urls = ["https://static.crates.io/crates/tokio-stream/0.1.17/download"],
         strip_prefix = "tokio-stream-0.1.17",
         build_file = Label("//vendor/cargo:BUILD.tokio-stream-0.1.17.bazel"),
-    )
-
-    maybe(
-        http_archive,
-        name = "cargo_vendor__tokio-tar-0.3.1",
-        sha256 = "9d5714c010ca3e5c27114c1cdeb9d14641ace49874aa5626d7149e47aedace75",
-        type = "tar.gz",
-        urls = ["https://static.crates.io/crates/tokio-tar/0.3.1/download"],
-        strip_prefix = "tokio-tar-0.3.1",
-        build_file = Label("//vendor/cargo:BUILD.tokio-tar-0.3.1.bazel"),
     )
 
     maybe(
@@ -11977,7 +11980,7 @@ def crate_repositories():
         struct(repo = "cargo_vendor__syn-2.0.106", is_dev_dep = False),
         struct(repo = "cargo_vendor__target-spec-3.5.2", is_dev_dep = False),
         struct(repo = "cargo_vendor__target-triple-0.1.4", is_dev_dep = False),
-        struct(repo = "cargo_vendor__testcontainers-0.25.0", is_dev_dep = False),
+        struct(repo = "cargo_vendor__testcontainers-0.25.2", is_dev_dep = False),
         struct(repo = "cargo_vendor__thiserror-2.0.16", is_dev_dep = False),
         struct(repo = "cargo_vendor__tokio-1.47.1", is_dev_dep = False),
         struct(repo = "cargo_vendor__tokio-rustls-0.26.2", is_dev_dep = False),


### PR DESCRIPTION
Updates `testcontainers` to 0.25.2 which includes a change that removes the `tokio-tar` dependency.
Mitigates https://rustsec.org/advisories/RUSTSEC-2025-0111.